### PR TITLE
WIP: Implement streaming completions

### DIFF
--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -30,14 +30,11 @@ module LLM
       params = DEFAULT_PARAMS.merge(params)
       body = {messages: messages.map(&:to_h)}.merge!(params)
       req = preflight(req, body)
-      puts req.body
       if params[:stream]
         Fiber.new do
           @http.request(req) do |res|
             res.read_body do |chunk|
               chunk.scan(/^data:(.+)$/).each do |match|
-                break if match[0].strip == "[DONE]"
-                next if match[0].strip.empty?
                 Fiber.yield Response::Chunk.new(match[0], self).extend(response_parser)
               end
             end

--- a/lib/llm/providers/openai/response_parser.rb
+++ b/lib/llm/providers/openai/response_parser.rb
@@ -26,5 +26,18 @@ class LLM::OpenAI
         total_tokens: raw.dig("usage", "total_tokens")
       }
     end
+
+    ##
+    # @param [Hash] raw
+    #  The raw response from the LLM provider
+    # @return [Hash]
+    def parse_completion_chunk(raw)
+      {
+        model: raw["model"],
+        choices: raw["choices"].map do
+          LLM::Message.new(*_1["delta"].values_at("role", "content"))
+        end
+      }
+    end
   end
 end

--- a/lib/llm/response.rb
+++ b/lib/llm/response.rb
@@ -3,6 +3,7 @@
 module LLM
   class Response
     require "json"
+    require_relative "response/chunk"
     require_relative "response/completion"
     require_relative "response/embedding"
 

--- a/lib/llm/response.rb
+++ b/lib/llm/response.rb
@@ -3,8 +3,8 @@
 module LLM
   class Response
     require "json"
-    require_relative "response/chunk"
     require_relative "response/completion"
+    require_relative "response/chunk"
     require_relative "response/embedding"
 
     ##

--- a/lib/llm/response/chunk.rb
+++ b/lib/llm/response/chunk.rb
@@ -1,21 +1,8 @@
 # frozen_string_literal: true
 
 module LLM
-  class Response::Chunk < Response
-    ##
-    # @return [String]
-    #   Returns the model name used for the completion
-    def model
-      parsed[:model]
-    end
-
-    ##
-    # @return [Array<LLM::Message>]
-    #  Returns an array of messages
-    def choices
-      parsed[:choices]
-    end
-
+  require_relative "completion"
+  class Response::Chunk < Response::Completion
     private
 
     ##

--- a/lib/llm/response/chunk.rb
+++ b/lib/llm/response/chunk.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module LLM
+  class Response::Chunk < Response
+    ##
+    # @return [String]
+    #   Returns the model name used for the completion
+    def model
+      parsed[:model]
+    end
+
+    ##
+    # @return [Array<LLM::Message>]
+    #  Returns an array of messages
+    def choices
+      parsed[:choices]
+    end
+
+    private
+
+    ##
+    # @private
+    # @return [Hash]
+    #  Returns the parsed completion response from the provider
+    def parsed
+      @parsed ||= parse_completion_chunk(raw)
+    end
+  end
+end

--- a/lib/llm/response/chunk.rb
+++ b/lib/llm/response/chunk.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module LLM
-  require_relative "completion"
   class Response::Chunk < Response::Completion
     private
 


### PR DESCRIPTION
## Changes
- Added `Chunk` response to represent a streamed completion chunk
- Added streaming capability for OpenAI

## Examples
```ruby
completion = LLM.openai(KEY).complete Message.new("user", "write a small story"), stream: true
result = ""
while chunk = completion.resume
  result << chunk.choices.first.content
end
puts result
```