### PR TITLE
Maintain message thread in LLM::Conversation

### DIFF
--- a/lib/llm/conversation.rb
+++ b/lib/llm/conversation.rb
@@ -30,8 +30,8 @@ module LLM
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
       tap do
-        completion = @provider.complete(prompt, role, **params)
-        @messages.concat [Message.new(role.to_s, prompt), completion.choices[0]]
+        completion = @provider.complete(prompt, role, **params.merge(messages:))
+        @messages.concat [Message.new(role, prompt), completion.choices[0]]
       end
     end
   end

--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -37,5 +37,19 @@ module LLM
     def to_h
       {role:, content:}
     end
+
+    ##
+    # @param [Object] other
+    #  The other object to compare
+    # @return [Boolean]
+    #  Returns true when the "other" object has the same role and content
+    def ==(other)
+      if other.respond_to?(:to_h)
+        to_h == other.to_h
+      else
+        false
+      end
+    end
+    alias_method :eql?, :==
   end
 end

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -51,8 +51,8 @@ module LLM
     def format_prompt(prompt)
       if URI === prompt
         [{
-           type: :image,
-           source: { type: :base64, media_type: prompt.content_type, data: [prompt.to_s].pack("m0") }
+          type: :image,
+          source: {type: :base64, media_type: prompt.content_type, data: [prompt.to_s].pack("m0")}
         }]
       else
         prompt

--- a/spec/llm/conversation_spec.rb
+++ b/spec/llm/conversation_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe LLM::Conversation do
+  shared_examples "a multi-turn conversation" do
+    context "when given a thread of messages" do
+      let(:inputs) do
+        [
+          LLM::Message.new(:system, "Provide concise, short answers about The Netherlands"),
+          LLM::Message.new(:user, "What is the capital of The Netherlands?"),
+          LLM::Message.new(:user, "How many people live in the capital?")
+        ]
+      end
+
+      let(:outputs) do
+        [
+          LLM::Message.new(:assistant, "Ok, got it"),
+          LLM::Message.new(:assistant, "The capital of The Netherlands is Amsterdam"),
+          LLM::Message.new(:assistant, "The population of Amsterdam is about 900,000")
+        ]
+      end
+
+      let(:messages) { [] }
+
+      it "maintains a conversation" do
+        bot = nil
+        inputs.zip(outputs).each_with_index do |(input, output), index|
+          expect(provider).to receive(:complete)
+                                .with(input.content, instance_of(Symbol), messages:)
+                                .and_return(OpenStruct.new(choices: [output]))
+          bot = index.zero? ? provider.chat!(input.content, :system) : bot.chat(input.content)
+          messages.concat([input, output])
+        end
+      end
+    end
+  end
+
+  context "with openai" do
+    subject(:provider) { LLM.openai("") }
+    include_examples "a multi-turn conversation"
+  end
+
+  context "with gemini" do
+    subject(:provider) { LLM.gemini("") }
+    include_examples "a multi-turn conversation"
+  end
+
+  context "with anthropic" do
+    subject(:provider) { LLM.anthropic("") }
+    include_examples "a multi-turn conversation"
+  end
+
+  context "with ollama" do
+    subject(:provider) { LLM.ollama("") }
+    include_examples "a multi-turn conversation"
+  end
+end


### PR DESCRIPTION
This change fixes a bug where non-lazy conversations would not 
maintain the message thread throughout a conversation. We forgot 
to forward the 'messages' attribute onto `LLM::Provider#complete`.

Also add tests