### PR TITLE
Add LLM::{Conversation,LazyConversation}#last_message

### DIFF
--- a/lib/llm/conversation.rb
+++ b/lib/llm/conversation.rb
@@ -34,5 +34,16 @@ module LLM
         @messages.concat [Message.new(role, prompt), completion.choices[0]]
       end
     end
+
+    ##
+    # @param [#to_s] role
+    #  The role of the last message.
+    #  Defaults to the LLM's assistant role (eg "assistant" or "model")
+    # @return [LLM::Message]
+    #  The last message for the given role
+    def last_message(role: @provider.assistant_role)
+      messages.reverse_each.find { _1.role == role.to_s }
+    end
+    alias_method :recent_message, :last_message
   end
 end

--- a/lib/llm/lazy_conversation.rb
+++ b/lib/llm/lazy_conversation.rb
@@ -35,5 +35,16 @@ module LLM
     def chat(prompt, role = :user, **params)
       tap { @messages << [prompt, role, params] }
     end
+
+    ##
+    # @param [#to_s] role
+    #  The role of the last message.
+    #  Defaults to the LLM's assistant role (eg "assistant" or "model")
+    # @return [LLM::Message]
+    #  The last message for the given role
+    def last_message(role: @provider.assistant_role)
+      messages.reverse_each.find { _1.role == role.to_s }
+    end
+    alias_method :recent_message, :last_message
   end
 end

--- a/lib/llm/message.rb
+++ b/lib/llm/message.rb
@@ -20,7 +20,7 @@ module LLM
     # @param [Hash] extra
     # @return [LLM::Message]
     def initialize(role, content, extra = {})
-      @role = role
+      @role = role.to_s
       @content = content
       @extra = extra
     end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -72,6 +72,14 @@ module LLM
       Conversation.new(self).chat(prompt, role, **params)
     end
 
+    ##
+    # @return [String]
+    #  The role of the assistant in the conversation.
+    #  Usually "assistant" or "model"
+    def assistant_role
+      raise NotImplementedError
+    end
+
     private
 
     ##

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -46,6 +46,12 @@ module LLM
       Response::Completion.new(res).extend(response_parser)
     end
 
+    ##
+    # @return (see LLM::Provider#assistant_role)
+    def assistant_role
+      "assistant"
+    end
+
     private
 
     def headers

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -44,6 +44,12 @@ module LLM
       Response::Completion.new(res).extend(response_parser)
     end
 
+    ##
+    # @return (see LLM::Provider#assistant_role)
+    def assistant_role
+      "model"
+    end
+
     private
 
     def headers

--- a/lib/llm/providers/ollama.rb
+++ b/lib/llm/providers/ollama.rb
@@ -32,6 +32,12 @@ module LLM
       Response::Completion.new(res).extend(response_parser)
     end
 
+    ##
+    # @return (see LLM::Provider#assistant_role)
+    def assistant_role
+      "assistant"
+    end
+
     private
 
     def headers

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -42,6 +42,12 @@ module LLM
       Response::Completion.new(res).extend(response_parser)
     end
 
+    ##
+    # @return (see LLM::Provider#assistant_role)
+    def assistant_role
+      "assistant"
+    end
+
     private
 
     def headers

--- a/spec/llm/lazy_conversation_spec.rb
+++ b/spec/llm/lazy_conversation_spec.rb
@@ -25,6 +25,30 @@ RSpec.describe LLM::LazyConversation do
           content: "I am doing well, thank you for asking!  How are you today?\n"
         )
       end
+
+      context "#recent_message" do
+        context "when filtered by the assistant role" do
+          subject(:message) { conversation.recent_message }
+
+          it "returns the most recent assistant message" do
+            expect(message).to have_attributes(
+              role: "model",
+              content: "I am doing well, thank you for asking!  How are you today?\n"
+            )
+          end
+        end
+
+        context "when filtered by the user role" do
+          subject(:message) { conversation.recent_message(role: "user") }
+
+          it "returns the most recent user message" do
+            expect(message).to have_attributes(
+              role: "user",
+              content: "How are you?"
+            )
+          end
+        end
+      end
     end
   end
 
@@ -47,6 +71,30 @@ RSpec.describe LLM::LazyConversation do
           role: "assistant",
           content: "I'm just a computer program, so I don't have feelings, but I'm here and ready to help! What’s your question?"
         )
+      end
+
+      context "#recent_message" do
+        context "when filtered by the assistant role" do
+          subject(:message) { conversation.recent_message }
+
+          it "returns the most recent assistant message" do
+            expect(message).to have_attributes(
+              role: "assistant",
+              content: "I'm just a computer program, so I don't have feelings, but I'm here and ready to help! What’s your question?"
+            )
+          end
+        end
+
+        context "when filtered by the user role" do
+          subject(:message) { conversation.recent_message(role: "user") }
+
+          it "returns the most recent user message" do
+            expect(message).to have_attributes(
+              role: "user",
+              content: "How are you?"
+            )
+          end
+        end
       end
     end
   end

--- a/spec/llm/lazy_conversation_spec.rb
+++ b/spec/llm/lazy_conversation_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe LLM::LazyConversation do
       end
 
       it "maintains a conversation" do
-        expect(message).to have_attributes(
+        is_expected.to have_attributes(
           role: "model",
           content: "I am doing well, thank you for asking!  How are you today?\n"
         )
@@ -31,7 +31,7 @@ RSpec.describe LLM::LazyConversation do
           subject(:message) { conversation.recent_message }
 
           it "returns the most recent assistant message" do
-            expect(message).to have_attributes(
+            is_expected.to have_attributes(
               role: "model",
               content: "I am doing well, thank you for asking!  How are you today?\n"
             )
@@ -42,7 +42,7 @@ RSpec.describe LLM::LazyConversation do
           subject(:message) { conversation.recent_message(role: "user") }
 
           it "returns the most recent user message" do
-            expect(message).to have_attributes(
+            is_expected.to have_attributes(
               role: "user",
               content: "How are you?"
             )
@@ -67,7 +67,7 @@ RSpec.describe LLM::LazyConversation do
       end
 
       it "maintains a conversation" do
-        expect(message).to have_attributes(
+        is_expected.to have_attributes(
           role: "assistant",
           content: "I'm just a computer program, so I don't have feelings, but I'm here and ready to help! What’s your question?"
         )
@@ -78,7 +78,7 @@ RSpec.describe LLM::LazyConversation do
           subject(:message) { conversation.recent_message }
 
           it "returns the most recent assistant message" do
-            expect(message).to have_attributes(
+            is_expected.to have_attributes(
               role: "assistant",
               content: "I'm just a computer program, so I don't have feelings, but I'm here and ready to help! What’s your question?"
             )
@@ -89,7 +89,7 @@ RSpec.describe LLM::LazyConversation do
           subject(:message) { conversation.recent_message(role: "user") }
 
           it "returns the most recent user message" do
-            expect(message).to have_attributes(
+            is_expected.to have_attributes(
               role: "user",
               content: "How are you?"
             )
@@ -126,7 +126,7 @@ RSpec.describe LLM::LazyConversation do
       end
 
       it "maintains a conversation" do
-        expect(message).to have_attributes(
+        is_expected.to have_attributes(
           role: "assistant",
           content: "Hello! How are you today?"
         )


### PR DESCRIPTION
This new method provides a short-hand way to reference the 
most recent message in a conversation, with an option to filter
 by the role of a message as well.

For example:
```ruby
message = conversation.last_message
message = conversation.last_message(role: 'assistant') 
message = conversation.last_message(role: 'user')
```

It is also aliased as `recent_message`
```ruby
message = conversation.recent_message
message = conversation.recent_message(role: 'assistant') 
message = conversation.recent_message(role: 'user')
```