### PR TITLE
Add LLM::Provider#models

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,22 @@ provider accepts:
 
 The
 [`LLM::Provider#embed`](https://0x1eef.github.io/x/llm/LLM/Provider.html#embed-instance_method)
-method generates a vector representation of a given piece of text.
-Embeddings capture the semantic meaning of text, and they are
-commonly used in tasks such as text similarity comparison (e.g., finding related documents),
-semantic search in vector databases, and the clustering and classification
-of text-based data:
+method generates a vector representation of one or more chunks
+of text. Embeddings capture the semantic meaning of text &ndash;
+a common use-case for them is to store chunks of text in a
+vector database, and then to query the database for *semantically
+similar* text. These chunks of similar text can then support the
+generation of a prompt that is used to query a large language model,
+which will go on to generate a response.
+
+For example, a user query might find similar text that adds important
+context to the prompt that informs the large language model in how to respond.
+The chunks of text may also carry metadata that can be used to further filter
+and contextualize the search results. This technique is popularly known as
+retrieval-augmented generation (RAG). Embeddings can also be used for
+other purposes as well &ndash; RAG is just one of the most popular use-cases.
+Let's take a look at an example that generates a couple of vectors
+for two chunks of text:
 
 ```ruby
 #!/usr/bin/env ruby

--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -6,6 +6,7 @@ module LLM
   require_relative "llm/message"
   require_relative "llm/response"
   require_relative "llm/file"
+  require_relative "llm/model"
   require_relative "llm/provider"
   require_relative "llm/conversation"
   require_relative "llm/lazy_conversation"

--- a/lib/llm/conversation.rb
+++ b/lib/llm/conversation.rb
@@ -20,8 +20,9 @@ module LLM
     ##
     # @param [LLM::Provider] provider
     #  A provider
-    def initialize(provider)
+    def initialize(provider, params = {})
       @provider = provider
+      @params = params
       @messages = []
     end
 
@@ -30,7 +31,7 @@ module LLM
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
       tap do
-        completion = @provider.complete(prompt, role, **params.merge(messages:))
+        completion = @provider.complete(prompt, role, **@params.merge(params.merge(messages:)))
         @messages.concat [Message.new(role, prompt), completion.choices[0]]
       end
     end

--- a/lib/llm/lazy_conversation.rb
+++ b/lib/llm/lazy_conversation.rb
@@ -24,8 +24,9 @@ module LLM
     ##
     # @param [LLM::Provider] provider
     #  A provider
-    def initialize(provider)
+    def initialize(provider, params = {})
       @provider = provider
+      @params = params
       @messages = LLM::MessageQueue.new(provider)
     end
 
@@ -33,7 +34,7 @@ module LLM
     # @param prompt (see LLM::Provider#prompt)
     # @return [LLM::Conversation]
     def chat(prompt, role = :user, **params)
-      tap { @messages << [prompt, role, params] }
+      tap { @messages << [prompt, role, @params.merge(params)] }
     end
 
     ##

--- a/lib/llm/model.rb
+++ b/lib/llm/model.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class LLM::Model < Struct.new(:name, :parameters, :description, :to_param, keyword_init: true)
+  def to_json(*)
+    to_param.to_json(*)
+  end
+end

--- a/lib/llm/provider.rb
+++ b/lib/llm/provider.rb
@@ -1,111 +1,130 @@
 # frozen_string_literal: true
 
-module LLM
-  require "llm/http_client"
+##
+# The Provider class represents an abstract class for
+# LLM (Language Model) providers
+class LLM::Provider
+  require_relative "http_client"
+  include LLM::HTTPClient
+
   ##
-  # The Provider class represents an abstract class for
-  # LLM (Language Model) providers
-  class Provider
-    include HTTPClient
-    ##
-    # @param [String] secret
-    #  The secret key for authentication
-    # @param [String] host
-    #  The host address of the LLM provider
-    # @param [Integer] port
-    #  The port number
-    def initialize(secret, host:, port: 443, ssl: true)
-      @secret = secret
-      @http = Net::HTTP.new(host, port).tap do |http|
-        http.use_ssl = ssl
-      end
+  # @param [String] secret
+  #  The secret key for authentication
+  # @param [String] host
+  #  The host address of the LLM provider
+  # @param [Integer] port
+  #  The port number
+  def initialize(secret, host:, port: 443, ssl: true)
+    @secret = secret
+    @http = Net::HTTP.new(host, port).tap do |http|
+      http.use_ssl = ssl
     end
+  end
 
-    ##
-    # Returns an inspection of the provider object
-    # @return [String]
-    # @note The secret key is redacted in inspect for security reasons
-    def inspect
-      "#<#{self.class.name}:0x#{object_id.to_s(16)} @secret=[REDACTED] @http=#{@http.inspect}>"
-    end
+  ##
+  # Returns an inspection of the provider object
+  # @return [String]
+  # @note The secret key is redacted in inspect for security reasons
+  def inspect
+    "#<#{self.class.name}:0x#{object_id.to_s(16)} @secret=[REDACTED] @http=#{@http.inspect}>"
+  end
 
-    ##
-    # @param [String, Array<String>] input
-    #  The input to embed
-    # @raise [NotImplementedError]
-    #  When the method is not implemented by a subclass
-    # @return [LLM::Response::Embedding]
-    def embed(input, **params)
-      raise NotImplementedError
-    end
+  ##
+  # @param [String, Array<String>] input
+  #  The input to embed
+  # @raise [NotImplementedError]
+  #  When the method is not implemented by a subclass
+  # @return [LLM::Response::Embedding]
+  def embed(input, **params)
+    raise NotImplementedError
+  end
 
-    ##
-    # Completes a given prompt using the LLM
-    # @param [String] prompt
-    #  The input prompt to be completed
-    # @param [Symbol] role
-    #  The role of the prompt (e.g. :user, :system)
-    # @raise [NotImplementedError]
-    #  When the method is not implemented by a subclass
-    # @return [LLM::Response::Completion]
-    def complete(prompt, role = :user, **params)
-      raise NotImplementedError
-    end
+  ##
+  # Completes a given prompt using the LLM
+  # @param [String] prompt
+  #  The input prompt to be completed
+  # @param [Symbol] role
+  #  The role of the prompt (e.g. :user, :system)
+  # @raise [NotImplementedError]
+  #  When the method is not implemented by a subclass
+  # @return [LLM::Response::Completion]
+  def complete(prompt, role = :user, **params)
+    raise NotImplementedError
+  end
 
-    ##
-    # Starts a new lazy conversation
-    # @param prompt (see LLM::Provider#complete)
-    # @param role (see LLM::Provider#complete)
-    # @raise (see LLM::Provider#complete)
-    # @return [LLM::LazyConversation]
-    def chat(prompt, role = :user, **params)
-      LazyConversation.new(self).chat(prompt, role, **params)
-    end
+  ##
+  # Starts a new lazy conversation
+  # @param prompt (see LLM::Provider#complete)
+  # @param role (see LLM::Provider#complete)
+  # @raise (see LLM::Provider#complete)
+  # @return [LLM::LazyConversation]
+  def chat(prompt, role = :user, **params)
+    LLM::LazyConversation.new(self, params).chat(prompt, role)
+  end
 
-    ##
-    # Starts a new conversation
-    # @param prompt (see LLM::Provider#complete)
-    # @param role (see LLM::Provider#complete)
-    # @raise (see LLM::Provider#complete)
-    # @return [LLM::Conversation]
-    def chat!(prompt, role = :user, **params)
-      Conversation.new(self).chat(prompt, role, **params)
-    end
+  ##
+  # Starts a new conversation
+  # @param prompt (see LLM::Provider#complete)
+  # @param role (see LLM::Provider#complete)
+  # @raise (see LLM::Provider#complete)
+  # @return [LLM::Conversation]
+  def chat!(prompt, role = :user, **params)
+    LLM::Conversation.new(self, params).chat(prompt, role)
+  end
 
-    ##
-    # @return [String]
-    #  The role of the assistant in the conversation.
-    #  Usually "assistant" or "model"
-    def assistant_role
-      raise NotImplementedError
-    end
+  ##
+  # @return [String]
+  #  The role of the assistant in the conversation.
+  #  Usually "assistant" or "model"
+  def assistant_role
+    raise NotImplementedError
+  end
 
-    private
+  ##
+  # @return [Hash<String, LLM::Model>]
+  #  A hash of available models
+  def models
+    raise NotImplementedError
+  end
 
-    ##
-    # The headers to include with a request
-    # @raise [NotImplementedError]
-    #  (see LLM::Provider#complete)
-    def headers
-      raise NotImplementedError
-    end
+  private
 
-    ##
-    # @return [Module]
-    #  Returns the module responsible for parsing a successful LLM response
-    # @raise [NotImplementedError]
-    #  (see LLM::Provider#complete)
-    def response_parser
-      raise NotImplementedError
-    end
+  ##
+  # The headers to include with a request
+  # @raise [NotImplementedError]
+  #  (see LLM::Provider#complete)
+  def headers
+    raise NotImplementedError
+  end
 
-    ##
-    # @return [Class]
-    #  Returns the class responsible for handling an unsuccessful LLM response
-    # @raise [NotImplementedError]
-    #  (see LLM::Provider#complete)
-    def error_handler
-      raise NotImplementedError
-    end
+  ##
+  # @return [Module]
+  #  Returns the module responsible for parsing a successful LLM response
+  # @raise [NotImplementedError]
+  #  (see LLM::Provider#complete)
+  def response_parser
+    raise NotImplementedError
+  end
+
+  ##
+  # @return [Class]
+  #  Returns the class responsible for handling an unsuccessful LLM response
+  # @raise [NotImplementedError]
+  #  (see LLM::Provider#complete)
+  def error_handler
+    raise NotImplementedError
+  end
+
+  ##
+  # @param [String] provider
+  #  The name of the provider
+  # @return [Hash<String, Hash>]
+  def load_models!(provider)
+    require "yaml" unless defined?(YAML)
+    rootdir  = File.realpath File.join(__dir__, "..", "..")
+    sharedir = File.join(rootdir, "share", "llm")
+    provider = provider.gsub(/[^a-z0-9]/i, "")
+    yaml     = File.join(sharedir, "models", "#{provider}.yml")
+    YAML.safe_load_file(yaml).transform_values { LLM::Model.new(_1) }
   end
 end

--- a/lib/llm/providers/anthropic.rb
+++ b/lib/llm/providers/anthropic.rb
@@ -52,6 +52,12 @@ module LLM
       "assistant"
     end
 
+    ##
+    # @return (see LLM::Provider#models)
+    def models
+      @models ||= load_models!("anthropic")
+    end
+
     private
 
     def headers

--- a/lib/llm/providers/gemini.rb
+++ b/lib/llm/providers/gemini.rb
@@ -50,6 +50,12 @@ module LLM
       "model"
     end
 
+    ##
+    # @return (see LLM::Provider#models)
+    def models
+      @models ||= load_models!("gemini")
+    end
+
     private
 
     def headers

--- a/lib/llm/providers/ollama.rb
+++ b/lib/llm/providers/ollama.rb
@@ -49,6 +49,12 @@ module LLM
       "assistant"
     end
 
+    ##
+    # @return (see LLM::Provider#models)
+    def models
+      @models ||= load_models!("ollama")
+    end
+
     private
 
     def headers

--- a/lib/llm/providers/openai.rb
+++ b/lib/llm/providers/openai.rb
@@ -48,6 +48,10 @@ module LLM
       "assistant"
     end
 
+    def models
+      @models ||= load_models!("openai")
+    end
+
     private
 
     def headers

--- a/share/llm/models/anthropic.yml
+++ b/share/llm/models/anthropic.yml
@@ -1,0 +1,35 @@
+claude-3-7-sonnet-20250219:
+  name: Claude 3.7 Sonnet
+  parameters: Unknown
+  description: Most intelligent Claude model with extended thinking and high capability
+  to_param: claude-3-7-sonnet-20250219
+
+claude-3-5-sonnet-20241022:
+  name: Claude 3.5 Sonnet (v2)
+  parameters: Unknown
+  description: High intelligence and capability; upgraded from previous Sonnet
+  to_param: claude-3-5-sonnet-20241022
+
+claude-3-5-sonnet-20240620:
+  name: Claude 3.5 Sonnet
+  parameters: Unknown
+  description: Intelligent and capable general-purpose model
+  to_param: claude-3-5-sonnet-20240620
+
+claude-3-5-haiku-20241022:
+  name: Claude 3.5 Haiku
+  parameters: Unknown
+  description: Blazing fast model for low-latency text generation
+  to_param: claude-3-5-haiku-20241022
+
+claude-3-opus-20240229:
+  name: Claude 3 Opus
+  parameters: Unknown
+  description: Top-level intelligence, fluency, and reasoning for complex tasks
+  to_param: claude-3-opus-20240229
+
+claude-3-haiku-20240307:
+  name: Claude 3 Haiku
+  parameters: Unknown
+  description: Fastest and most compact Claude model for near-instant responsiveness
+  to_param: claude-3-haiku-20240307

--- a/share/llm/models/gemini.yml
+++ b/share/llm/models/gemini.yml
@@ -1,0 +1,35 @@
+gemini-2.5-pro-exp-03-25:
+  name: Gemini
+  parameters: Unknown
+  description: Enhanced thinking and reasoning, multimodal understanding, advanced coding, and more
+  to_param: gemini-2.5-pro-exp-03-25
+
+gemini-2.0-flash:
+  name: Gemini
+  parameters: Unknown
+  description: Next generation features, speed, thinking, realtime streaming, and multimodal generation
+  to_param: gemini-2.0-flash
+
+gemini-2.0-flash-lite:
+  name: Gemini
+  parameters: Unknown
+  description: Cost efficiency and low latency
+  to_param: gemini-2.0-flash-lite
+
+gemini-1.5-flash:
+  name: Gemini
+  parameters: Unknown
+  description: Fast and versatile performance across a diverse variety of tasks
+  to_param: gemini-1.5-flash
+
+gemini-1.5-flash-8b:
+  name: Gemini
+  parameters: 8B
+  description: High volume and lower intelligence tasks
+  to_param: gemini-1.5-flash-8b
+
+gemini-1.5-pro:
+  name: Gemini
+  parameters: Unknown
+  description: Complex reasoning tasks requiring more intelligence
+  to_param: gemini-1.5-pro

--- a/share/llm/models/ollama.yml
+++ b/share/llm/models/ollama.yml
@@ -1,0 +1,130 @@
+---
+gemma3:1b:
+  name: Gemma
+  parameters: 1B
+  description: Lightweight version of Google's Gemma 3 language model, suitable for
+    low-resource environments
+  to_param: gemma3:1b
+gemma3:
+  name: Gemma
+  parameters: 4B
+  description: Balanced Gemma 3 model providing good accuracy with reasonable size
+  to_param: gemma3
+gemma3:12b:
+  name: Gemma
+  parameters: 12B
+  description: Larger Gemma 3 model offering improved reasoning and generation abilities
+  to_param: gemma3:12b
+gemma3:27b:
+  name: Gemma
+  parameters: 27B
+  description: High-end Gemma 3 model focused on top-tier performance and accuracy
+  to_param: gemma3:27b
+qwq:
+  name: QwQ
+  parameters: 32B
+  description: Large-scale model with high parameter count for complex tasks and
+    high-quality generation
+  to_param: qwq
+deepseek-r1:
+  name: DeepSeek-R1
+  parameters: 7B
+  description: Compact DeepSeek model optimized for research and experimentation
+  to_param: deepseek-r1
+deepseek-r1:671b:
+  name: DeepSeek-R1
+  parameters: 671B
+  description: Massive-scale DeepSeek model focused on advanced AI reasoning and
+    capabilities
+  to_param: deepseek-r1:671b
+llama3.3:
+  name: Llama
+  parameters: 70B
+  description: Latest large Llama model designed for high-end performance in reasoning
+    and language tasks
+  to_param: llama3.3
+llama3.2:
+  name: Llama
+  parameters: 3B
+  description: Small but capable version of Llama 3.2 for lightweight applications
+  to_param: llama3.2
+llama3.2:1b:
+  name: Llama
+  parameters: 1B
+  description: Tiny version of Llama 3.2, extremely lightweight and fast
+  to_param: llama3.2:1b
+llama3.2-vision:
+  name: Llama Vision
+  parameters: 11B
+  description: Multimodal Llama 3.2 model with vision capabilities (images + text)
+  to_param: llama3.2-vision
+llama3.2-vision:90b:
+  name: Llama Vision
+  parameters: 90B
+  description: Large-scale vision-capable Llama model for advanced multimodal tasks
+  to_param: llama3.2-vision:90b
+llama3.1:
+  name: Llama
+  parameters: 8B
+  description: General-purpose Llama model designed for good accuracy and performance
+    balance
+  to_param: llama3.1
+llama3.1:405b:
+  name: Llama
+  parameters: 405B
+  description: Extremely large-scale version of Llama 3.1, suitable for advanced
+    tasks
+  to_param: llama3.1:405b
+phi4:
+  name: Phi
+  parameters: 14B
+  description: Phi 4 is known for compact size and competitive performance in general
+    tasks
+  to_param: phi4
+phi4-mini:
+  name: Phi Mini
+  parameters: 3.8B
+  description: Lightweight variant of Phi 4 ideal for quick inference on constrained
+    systems
+  to_param: phi4-mini
+mistral:
+  name: Mistral
+  parameters: 7B
+  description: Popular and versatile open model for general language tasks
+  to_param: mistral
+moondream:
+  name: Moondream
+  parameters: 1.4B
+  description: Compact vision-enabled model with strong general performance
+  to_param: moondream
+neural-chat:
+  name: Neural Chat
+  parameters: 7B
+  description: Chat-focused model fine-tuned for natural conversations
+  to_param: neural-chat
+starling-lm:
+  name: Starling
+  parameters: 7B
+  description: Model focused on instruction-following and conversational performance
+  to_param: starling-lm
+codellama:
+  name: Code Llama
+  parameters: 7B
+  description: Llama model variant fine-tuned specifically for code understanding
+    and generation
+  to_param: codellama
+llama2-uncensored:
+  name: Llama 2 Uncensored
+  parameters: 7B
+  description: Unfiltered version of Llama 2 for unrestricted language modeling
+  to_param: llama2-uncensored
+llava:
+  name: LLaVA
+  parameters: 7B
+  description: Multimodal model combining vision and language understanding
+  to_param: llava
+granite3.2:
+  name: Granite
+  parameters: 8B
+  description: IBM’s Granite model for enterprise-grade language applications
+  to_param: granite3.2

--- a/share/llm/models/openai.yml
+++ b/share/llm/models/openai.yml
@@ -1,0 +1,46 @@
+---
+o3-mini:
+  name: OpenAI o3-mini
+  parameters: Unknown
+  description: Fast, flexible, intelligent reasoning model
+  to_param: o3-mini
+o1:
+  name: OpenAI o1
+  parameters: Unknown
+  description: High-intelligence reasoning model
+  to_param: o1
+o1-mini:
+  name: OpenAI o1-mini
+  parameters: Unknown
+  description: Faster, more affordable reasoning model than o1
+  to_param: o1-mini
+o1-pro:
+  name: OpenAI o1-pro
+  parameters: Unknown
+  description: More compute than o1 for better responses
+  to_param: o1-pro
+gpt-4.5-preview:
+  name: GPT-4.5 Preview
+  parameters: Unknown
+  description: Largest and most capable GPT model
+  to_param: gpt-4.5-preview
+gpt-4o:
+  name: GPT-4o
+  parameters: Unknown
+  description: Fast, intelligent, flexible GPT model
+  to_param: gpt-4o
+gpt-4o-mini:
+  name: GPT-4o Mini
+  parameters: Mini
+  description: Fast, affordable small model for focused tasks
+  to_param: gpt-4o-mini
+gpt-4o-realtime-preview:
+  name: GPT-4o Realtime
+  parameters: Unknown
+  description: Realtime model for text and audio inputs/outputs
+  to_param: gpt-4o-realtime-preview
+gpt-3.5-turbo:
+  name: GPT-3.5 Turbo
+  parameters: Unknown
+  description: Legacy GPT model for cheaper chat and non-chat tasks
+  to_param: gpt-3.5-turbo

--- a/spec/fixtures/cassettes/openai/lazy_conversation/successful_response_o3_mini.yml
+++ b/spec/fixtures/cassettes/openai/lazy_conversation/successful_response_o3_mini.yml
@@ -1,0 +1,225 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"system","content":"Keep your answers short and
+        concise, and provide three answers to the three questions"}],"model":"o3-mini"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Mar 2025 13:29:25 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Processing-Ms:
+      - '6202'
+      Openai-Version:
+      - '2020-10-01'
+      X-Ratelimit-Limit-Requests:
+      - '500'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '499'
+      X-Ratelimit-Remaining-Tokens:
+      - '199976'
+      X-Ratelimit-Reset-Requests:
+      - 120ms
+      X-Ratelimit-Reset-Tokens:
+      - 7ms
+      X-Request-Id:
+      - req_cecc91d399d66298b9511ebef91d2bca
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=27k47u_MXOFjirdfV1rCwfCfSwIqC2dug3F7QggwAZs-1743168565-1.0.1.1-RR7cTYgTkSI1qSHqeeUrR1cCKB1zGOsv0uUiJYGIlX9yFtTUeLUC9MZnKEmWXnWpn8MZVuwbn2RdEAB2Bc0WIHqp3qR.mIa3A.r0Rb6zqOg;
+        path=/; expires=Fri, 28-Mar-25 13:59:25 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=ED9KjJMi2WhnADyk1.W1.YFEFlSMGq4NQtLLGvj1P4o-1743168565458-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 927779c62d12a52f-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-BG43rbch4fX6KPDSymrHDPW010qD0",
+          "object": "chat.completion",
+          "created": 1743168559,
+          "model": "o3-mini-2025-01-31",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "I don't see the three questions you're referring to. Could you clarify which questions you'd like answered?",
+                "refusal": null,
+                "annotations": []
+              },
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 21,
+            "completion_tokens": 478,
+            "total_tokens": 499,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 448,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_617f206dd9"
+        }
+  recorded_at: Fri, 28 Mar 2025 13:29:23 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"system","content":"Keep your answers short and
+        concise, and provide three answers to the three questions"},{"role":"assistant","content":"I
+        don''t see the three questions you''re referring to. Could you clarify which
+        questions you''d like answered?"},{"role":"user","content":"What is 5+5?"}],"model":"o3-mini"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Mar 2025 13:29:31 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Processing-Ms:
+      - '5641'
+      Openai-Version:
+      - '2020-10-01'
+      X-Ratelimit-Limit-Requests:
+      - '500'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '499'
+      X-Ratelimit-Remaining-Tokens:
+      - '199945'
+      X-Ratelimit-Reset-Requests:
+      - 120ms
+      X-Ratelimit-Reset-Tokens:
+      - 16ms
+      X-Request-Id:
+      - req_799d1295fe4833ffdb2461d13b401dda
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=JFhQ_kQG.0l5DrPaqWNYV.vNiaAFMaJlGM8mSwKyzoQ-1743168571-1.0.1.1-92FKVh3o__Pm.wdLywz7bmPeHm0O8YSty3KClWOOmXfEL7SI51f_vpBaokHSrBwCBKn3hmmo3FSZXWGbQF1J48Ax4RT9rKrY_cayXcirYIU;
+        path=/; expires=Fri, 28-Mar-25 13:59:31 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=Qw72ORQkktmDImuiUToBXZYfP5H4IGJglwqexHFDn2I-1743168571391-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 927779ee790e1cf1-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-BG43xBNQJSE5gI2ORzjSqsRvsR7lO",
+          "object": "chat.completion",
+          "created": 1743168565,
+          "model": "o3-mini-2025-01-31",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "1. 5 + 5 = 10  \n2. The sum is 10  \n3. Ten",
+                "refusal": null,
+                "annotations": []
+              },
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 55,
+            "completion_tokens": 353,
+            "total_tokens": 408,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 320,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_617f206dd9"
+        }
+  recorded_at: Fri, 28 Mar 2025 13:29:29 GMT
+recorded_with: VCR 6.3.1

--- a/spec/llm/lazy_conversation_spec.rb
+++ b/spec/llm/lazy_conversation_spec.rb
@@ -30,12 +30,12 @@ RSpec.describe LLM::LazyConversation do
     end
   end
 
-  context "with openai",
-          vcr: {cassette_name: "openai/lazy_conversation/successful_response"} do
+  context "with openai"  do
     let(:provider) { LLM.openai(token) }
     let(:conversation) { described_class.new(provider) }
 
-    context "when given a thread of messages" do
+    context "when given a thread of messages",
+            vcr: {cassette_name: "openai/lazy_conversation/successful_response"} do
       subject(:message) { conversation.recent_message }
 
       before do
@@ -50,6 +50,18 @@ RSpec.describe LLM::LazyConversation do
           role: "assistant",
           content: "1. 5  \n2. 10  \n3. 12  "
         )
+      end
+    end
+
+    context "when given a specific model",
+            vcr: {cassette_name: "openai/lazy_conversation/successful_response_o3_mini"} do
+      let(:conversation) { described_class.new(provider, model: provider.models["o3-mini"]) }
+
+      it "maintains the model throughout a conversation" do
+        conversation.chat(prompt, :system)
+        expect(conversation.recent_message.extra[:completion].model).to eq("o3-mini-2025-01-31")
+        conversation.chat("What is 5+5?")
+        expect(conversation.recent_message.extra[:completion].model).to eq("o3-mini-2025-01-31")
       end
     end
   end


### PR DESCRIPTION
This new method returns a Hash where the key is the model name,
and the value is an instance of LLM::Model. Each LLM::Model describes
the character of a model, and it can be used in place of a model name.
For example:
```ruby
llm = LLM.ollama(nil)
convo = llm.chat "How are you?", model: llm.models["deepseek-r1"]
```
The other notable change included in this diff is that when you start
a conversation with a given model, that choice is remembered throughout
the conversation (along with any other parameters that the conversation
is created with).