### PR TITLE
Add stream support via Server-Side Events (SSE) 

### DIFF
--- a/lib/llm.rb
+++ b/lib/llm.rb
@@ -17,6 +17,8 @@ module LLM
   require_relative "llm/chat"
   require_relative "llm/buffer"
   require_relative "llm/function"
+  require_relative "llm/eventstream"
+  require_relative "llm/event_handler"
 
   module_function
 

--- a/lib/llm/event_handler.rb
+++ b/lib/llm/event_handler.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module LLM
+  ##
+  # @private
+  class EventHandler
+    ##
+    # @param [#<<] stream Streamable
+    # @return [LLM::EventHandler]
+    def initialize(parser)
+      @parser = parser
+    end
+
+    ##
+    # "data:" event callback
+    # @param [LLM::EventStream::Event] event
+    # @return [void]
+    def on_data(event)
+      return if event.end?
+      chunk = JSON.parse(event.value)
+      @parser.parse!(chunk)
+    rescue JSON::ParserError
+    end
+
+    ##
+    # Callback for when *any* of chunk of data
+    # is received, regardless of whether it has
+    # a field name or not. Primarily for ollama,
+    # which does emit Server-Sent Events (SSE).
+    # @param [LLM::EventStream::Event] event
+    # @return [void]
+    def on_chunk(event)
+      return if event.end?
+      chunk = JSON.parse(event.chunk)
+      @parser.parse!(chunk)
+    rescue JSON::ParserError
+    end
+
+    ##
+    # Returns a fully constructed response body
+    # @return [LLM::Object]
+    def body = @parser.body
+  end
+end

--- a/lib/llm/eventstream.rb
+++ b/lib/llm/eventstream.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module LLM::EventStream
+  require_relative "eventstream/parser"
+  require_relative "eventstream/event"
+end

--- a/lib/llm/eventstream/event.rb
+++ b/lib/llm/eventstream/event.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module LLM::EventStream
+  ##
+  # @private
+  class Event
+    FIELD_REGEXP = /[^:]+/
+    VALUE_REGEXP = /(?<=: ).+/
+
+    ##
+    # Returns the field name
+    # @return [Symbol]
+    attr_reader :field
+
+    ##
+    # Returns the field value
+    # @return [String]
+    attr_reader :value
+
+    ##
+    # Returns the full chunk
+    # @return [String]
+    attr_reader :chunk
+
+    ##
+    # @param [String] chunk
+    # @return [LLM::EventStream::Event]
+    def initialize(chunk)
+      @field = chunk[FIELD_REGEXP]
+      @value = chunk[VALUE_REGEXP]
+      @chunk = chunk
+    end
+
+    ##
+    # Returns true when the event represents an "id" chunk
+    # @return [Boolean]
+    def id?
+      @field == "id"
+    end
+
+    ##
+    # Returns true when the event represents a "data" chunk
+    # @return [Boolean]
+    def data?
+      @field == "data"
+    end
+
+    ##
+    # Returns true when the event represents an "event" chunk
+    # @return [Boolean]
+    def event?
+      @field == "event"
+    end
+
+    ##
+    # Returns true when the event represents a "retry" chunk
+    # @return [Boolean]
+    def retry?
+      @field == "retry"
+    end
+
+    ##
+    # Returns true when a chunk represents the end of the stream
+    # @retuen [Boolean]
+    def end?
+      @value == "[DONE]"
+    end
+  end
+end

--- a/lib/llm/eventstream/parser.rb
+++ b/lib/llm/eventstream/parser.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module LLM::EventStream
+  ##
+  # @private
+  class Parser
+    ##
+    # @return [LLM::EventStream::Parser]
+    def initialize
+      @buffer = StringIO.new
+      @events = Hash.new { |h, k| h[k] = [] }
+      @offset = 0
+      @visitors = []
+    end
+
+    ##
+    # Register a visitor
+    # @param [#on_data] visitor
+    # @return [void]
+    def register(visitor)
+      @visitors << visitor
+    end
+
+    ##
+    # Subscribe to an event
+    # @param [Symbol] event
+    # @param [Proc] block
+    # @return [void]
+    def on(evtname, &block)
+      @events[evtname.to_s] << block
+    end
+
+    ##
+    # Append an event to the internal buffer
+    # @return [void]
+    def <<(event)
+      io = StringIO.new(event)
+      IO.copy_stream io, @buffer
+      each_line { parse!(_1) }
+    end
+
+    ##
+    # Returns the internal buffer
+    # @return [String]
+    def body
+      @buffer.string
+    end
+
+    ##
+    # Free the internal buffer
+    # @return [void]
+    def free
+      @buffer.truncate(0)
+      @buffer.rewind
+    end
+
+    private
+
+    def parse!(event)
+      event = Event.new(event)
+      dispatch(event)
+    end
+
+    def dispatch(event)
+      @visitors.each { dispatch_visitor(_1, event) }
+      @events[event.field].each { _1.call(event) }
+    end
+
+    def dispatch_visitor(visitor, event)
+      method = "on_#{event.field}"
+      if visitor.respond_to?(method)
+        visitor.public_send(method, event)
+      elsif visitor.respond_to?("on_chunk")
+        visitor.on_chunk(event)
+      end
+    end
+
+    def each_line
+      string.each_line.with_index do
+        next if _2 < @offset
+        yield(_1)
+        @offset += 1
+      end
+    end
+
+    def string = @buffer.string
+  end
+end

--- a/lib/llm/object.rb
+++ b/lib/llm/object.rb
@@ -17,7 +17,7 @@ class LLM::Object < BasicObject
   ##
   # @param [Hash] h
   # @return [LLM::Object]
-  def initialize(h)
+  def initialize(h = {})
     @h = h.transform_keys(&:to_sym) || h
   end
 
@@ -49,6 +49,12 @@ class LLM::Object < BasicObject
   # @return [String]
   def to_json(...)
     to_h.to_json(...)
+  end
+
+  ##
+  # @return [Boolean]
+  def empty?
+    @h.empty?
   end
 
   ##

--- a/lib/llm/object/builder.rb
+++ b/lib/llm/object/builder.rb
@@ -9,7 +9,7 @@ class LLM::Object
     #   obj = LLM::Object.from_hash(person: {name: 'John'})
     #   obj.person.name  # => 'John'
     #   obj.person.class # => LLM::Object
-    # @param [Hash, Array] obj
+    # @param [Hash, LLM::Object, Array] obj
     #   A Hash object
     # @return [LLM::Object]
     #   An LLM::Object object initialized by visiting `obj` with recursion
@@ -19,20 +19,19 @@ class LLM::Object
       when Array then obj.map { |v| from_hash(v) }
       else
         visited = {}
-        obj.each { visited[_1] = walk(_2) }
+        obj.each { visited[_1] = visit(_2) }
         new(visited)
       end
     end
 
     private
 
-    def walk(value)
-      if Hash === value
-        from_hash(value)
-      elsif Array === value
-        value.map { |v| (Hash === v) ? from_hash(v) : v }
-      else
-        value
+    def visit(value)
+      case value
+      when self then from_hash(value.to_h)
+      when Hash then from_hash(value)
+      when Array then value.map { |v| visit(v) }
+      else value
       end
     end
   end

--- a/lib/llm/providers/anthropic/response_parser.rb
+++ b/lib/llm/providers/anthropic/response_parser.rb
@@ -4,6 +4,7 @@ class LLM::Anthropic
   ##
   # @private
   module ResponseParser
+    require_relative "response_parser/completion_parser"
     def parse_embedding(body)
       {
         model: body["model"],

--- a/lib/llm/providers/anthropic/response_parser/completion_parser.rb
+++ b/lib/llm/providers/anthropic/response_parser/completion_parser.rb
@@ -41,9 +41,9 @@ module LLM::Anthropic::ResponseParser
     def body = @body
     def role = body.role
     def model = body.model
-    def prompt_tokens = body.usage.input_tokens
-    def completion_tokens = body.usage.output_tokens
-    def total_tokens = body.usage.total_tokens
+    def prompt_tokens = body.usage&.input_tokens
+    def completion_tokens = body.usage&.output_tokens
+    def total_tokens = body.usage&.total_tokens
     def parts = body.content
     def texts = parts.select { _1["type"] == "text" }
     def tools = parts.select { _1["type"] == "tool_use" }

--- a/lib/llm/providers/anthropic/stream_parser.rb
+++ b/lib/llm/providers/anthropic/stream_parser.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class LLM::Anthropic
+  ##
+  # @private
+  class StreamParser
+    ##
+    # Returns the fully constructed response body
+    # @return [LLM::Object]
+    attr_reader :body
+
+    ##
+    # @param [#<<] io An IO-like object
+    # @return [LLM::Anthropic::StreamParser]
+    def initialize(io)
+      @body = LLM::Object.new
+      @io = io
+    end
+
+    ##
+    # @param [Hash] chunk
+    # @return [LLM::Anthropic::StreamParser]
+    def parse!(chunk)
+      tap { merge!(chunk) }
+    end
+
+    private
+
+    def merge!(chunk)
+      if chunk["type"] == "message_start"
+        merge_message!(chunk["message"])
+      elsif chunk["type"] == "content_block_start"
+        @body["content"] ||= []
+        @body["content"][chunk["index"]] = chunk["content_block"]
+      elsif chunk["type"] == "content_block_delta"
+        if chunk["delta"]["type"] == "text_delta"
+          @body.content[chunk["index"]]["text"] << chunk["delta"]["text"]
+          @io << chunk["delta"]["text"] if @io.respond_to?(:<<)
+        elsif chunk["delta"]["type"] == "input_json_delta"
+          content = @body.content[chunk["index"]]
+          if Hash === content["input"]
+            content["input"] = chunk["delta"]["partial_json"]
+          else
+            content["input"] << chunk["delta"]["partial_json"]
+          end
+        end
+      elsif chunk["type"] == "message_delta"
+        merge_message!(chunk["delta"])
+      elsif chunk["type"] == "content_block_stop"
+        content = @body.content[chunk["index"]]
+        if content["input"]
+          content["input"] = JSON.parse(content["input"])
+        end
+      end
+    end
+
+    def merge_message!(message)
+      message.each do |key, value|
+        @body[key] = if value.respond_to?(:each_pair)
+          merge_message!(value)
+        else
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/llm/providers/gemini/stream_parser.rb
+++ b/lib/llm/providers/gemini/stream_parser.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class LLM::Gemini
+  ##
+  # @private
+  class StreamParser
+    ##
+    # Returns the fully constructed response body
+    # @return [LLM::Object]
+    attr_reader :body
+
+    ##
+    # @param [#<<] io An IO-like object
+    # @return [LLM::Gemini::StreamParser]
+    def initialize(io)
+      @body = LLM::Object.new
+      @io = io
+    end
+
+    ##
+    # @param [Hash] chunk
+    # @return [LLM::Gemini::StreamParser]
+    def parse!(chunk)
+      tap { merge!(chunk) }
+    end
+
+    private
+
+    def merge!(chunk)
+      chunk.each do |key, value|
+        if key == "candidates"
+          @body.candidates ||= []
+          merge_candidates!(value)
+        else
+          @body[key] = value
+        end
+      end
+    end
+
+    def merge_candidates!(candidates)
+      candidates.each.with_index do |candidate, i|
+        if @body.candidates[i]
+          parts = @body.candidates[i].dig("content", "parts")
+          parts&.each&.with_index do |part, j|
+            if part["text"]
+              target = candidate["content"]["parts"][j]
+              part["text"] << target["text"]
+              @io << part["text"] if @io.respond_to?(:<<)
+            end
+          end
+        else
+          @body.candidates[i] = candidate
+        end
+      end
+    end
+  end
+end

--- a/lib/llm/providers/ollama.rb
+++ b/lib/llm/providers/ollama.rb
@@ -21,7 +21,7 @@ module LLM
   class Ollama < Provider
     require_relative "ollama/error_handler"
     require_relative "ollama/format"
-    require_relative "ollama/stream_parser"   
+    require_relative "ollama/stream_parser"
     require_relative "ollama/response_parser"
     require_relative "ollama/models"
 

--- a/lib/llm/providers/ollama.rb
+++ b/lib/llm/providers/ollama.rb
@@ -20,9 +20,11 @@ module LLM
   #   bot.messages.select(&:assistant?).each { print "[#{_1.role}]", _1.content, "\n" }
   class Ollama < Provider
     require_relative "ollama/error_handler"
-    require_relative "ollama/response_parser"
     require_relative "ollama/format"
+    require_relative "ollama/stream_parser"   
+    require_relative "ollama/response_parser"
     require_relative "ollama/models"
+
     include Format
 
     HOST = "localhost"
@@ -59,14 +61,15 @@ module LLM
     #  When given an object a provider does not understand
     # @return (see LLM::Provider#complete)
     def complete(prompt, params = {})
-      params = {role: :user, model: default_model, stream: false}.merge!(params)
+      params = {role: :user, model: default_model}.merge!(params)
       params = [params, {format: params[:schema]}, format_tools(params)].inject({}, &:merge!).compact
-      role = params.delete(:role)
+      role, stream = params.delete(:role), params.delete(:stream)
+      params[:stream] = true if stream.respond_to?(:<<) || stream == true
       req = Net::HTTP::Post.new("/api/chat", headers)
       messages = [*(params.delete(:messages) || []), LLM::Message.new(role, prompt)]
       body = JSON.dump({messages: [format(messages)].flatten}.merge!(params))
       set_body_stream(req, StringIO.new(body))
-      res = request(@http, req)
+      res = params[:stream] ? stream(@http, req, stream) : request(@http, req)
       Response::Completion.new(res).extend(response_parser)
     end
 
@@ -103,6 +106,10 @@ module LLM
 
     def response_parser
       LLM::Ollama::ResponseParser
+    end
+
+    def stream_parser
+      LLM::Ollama::StreamParser
     end
 
     def error_handler

--- a/lib/llm/providers/ollama/stream_parser.rb
+++ b/lib/llm/providers/ollama/stream_parser.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class LLM::Ollama
+  ##
+  # @private
+  class StreamParser
+    ##
+    # Returns the fully constructed response body
+    # @return [LLM::Object]
+    attr_reader :body
+
+    ##
+    # @return [LLM::OpenAI::Chunk]
+    def initialize(io)
+      @body = LLM::Object.new
+      @io = io
+    end
+
+    ##
+    # @param [Hash] chunk
+    # @return [LLM::OpenAI::Chunk]
+    def parse!(chunk)
+      tap { merge!(chunk) }
+    end
+
+    private
+
+    def merge!(chunk)
+      chunk.each do |key, value|
+        if key == "message"
+          if @body[key]
+            @body[key]["content"] << value["content"]
+            @io << value["content"] if @io.respond_to?(:<<)
+          else
+            @body[key] = value
+            @io << value["content"] if @io.respond_to?(:<<)
+          end
+        else
+          @body[key] = value
+        end
+      end
+    end
+  end
+end

--- a/lib/llm/providers/openai/response_parser.rb
+++ b/lib/llm/providers/openai/response_parser.rb
@@ -4,6 +4,9 @@ class LLM::OpenAI
   ##
   # @private
   module ResponseParser
+    require_relative "response_parser/completion_parser"
+    require_relative "response_parser/respond_parser"
+
     ##
     # @param [Hash] body
     #  The response body from the LLM provider

--- a/lib/llm/providers/openai/response_parser/completion_parser.rb
+++ b/lib/llm/providers/openai/response_parser/completion_parser.rb
@@ -47,9 +47,9 @@ module LLM::OpenAI::ResponseParser
 
     def body = @body
     def model = body.model
-    def prompt_tokens = body.usage.prompt_tokens
-    def completion_tokens = body.usage.completion_tokens
-    def total_tokens = body.usage.total_tokens
+    def prompt_tokens = body.usage&.prompt_tokens
+    def completion_tokens = body.usage&.completion_tokens
+    def total_tokens = body.usage&.total_tokens
     def choices = body.choices
   end
 end

--- a/lib/llm/providers/openai/stream_parser.rb
+++ b/lib/llm/providers/openai/stream_parser.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class LLM::OpenAI
+  ##
+  # @private
+  class StreamParser
+    ##
+    # Returns the fully constructed response body
+    # @return [LLM::Object]
+    attr_reader :body
+
+    ##
+    # @return [LLM::OpenAI::Chunk]
+    def initialize(io)
+      @body = LLM::Object.new
+      @io = io
+    end
+
+    ##
+    # @param [Hash] chunk
+    # @return [LLM::OpenAI::Chunk]
+    def parse!(chunk)
+      tap { merge!(chunk) }
+    end
+
+    private
+
+    def merge!(chunk)
+      chunk.each do |key, value|
+        if key == "choices"
+          @body["choices"] ||= []
+          merge_choices!(value)
+        else
+          @body[key] = value
+        end
+      end
+    end
+
+    def merge_choices!(choices)
+      choices.each do |choice|
+        if @body.choices[choice["index"]]
+          target = @body["choices"][choice["index"]]["message"]
+          delta = choice["delta"]
+          delta.each do |key, value|
+            if target[key]
+              if key == "content"
+                target[key] << value
+                @io << value if @io.respond_to?(:<<)
+              elsif key == "tool_calls"
+                merge_tools!(target, value)
+              else
+                target[key] = value
+              end
+            else
+              target[key] = value
+            end
+          end
+        else
+          target = {"message" => {"role" => "assistant"}}
+          @body["choices"][choice["index"]] = target
+          target["message"].merge!(choice["delta"])
+        end
+      end
+    end
+
+    def merge_tools!(target, tools)
+      tools.each.with_index do |toola, index|
+        toolb = target["tool_calls"][index]
+        if toolb
+          toola["function"].each { toolb["function"][_1] << _2 }
+        else
+          target["tool_calls"][index] = toola
+        end
+      end
+    end
+  end
+end

--- a/spec/anthropic/chat_spec.rb
+++ b/spec/anthropic/chat_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "LLM::Chat: anthropic" do
 
   context LLM::Chat do
     include_examples "LLM::Chat: completions", :anthropic
+    include_examples "LLM::Chat: text stream", :anthropic
+    include_examples "LLM::Chat: tool stream", :anthropic
   end
 
   context LLM::Function do

--- a/spec/deepseek/chat_spec.rb
+++ b/spec/deepseek/chat_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "LLM::Chat: openai" do
 
   context LLM::Chat do
     include_examples "LLM::Chat: completions", :deepseek
+    include_examples "LLM::Chat: text stream", :deepseek
+    include_examples "LLM::Chat: tool stream", :deepseek
   end
 
   context LLM::Function do

--- a/spec/fixtures/cassettes/anthropic/chat/llm_chat_stream_stringio.yml
+++ b/spec/fixtures/cassettes/anthropic/chat/llm_chat_stream_stringio.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"type":"text","text":"Keep
+        your answers short and concise, and provide three answers to the three questions.
+        There should be one answer per line. An answer should be a number, for example:
+        5. Nothing else"}]},{"role":"user","content":[{"type":"text","text":"What
+        is 3+2 ?"}]},{"role":"user","content":[{"type":"text","text":"What is 5+5
+        ?"}]},{"role":"user","content":[{"type":"text","text":"What is 5+7 ?"}]}],"model":"claude-3-5-sonnet-20240620","max_tokens":1024,"stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - TOKEN
+      Anthropic-Version:
+      - '2023-06-01'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 23 May 2025 22:12:00 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Anthropic-Ratelimit-Input-Tokens-Limit:
+      - '40000'
+      Anthropic-Ratelimit-Input-Tokens-Remaining:
+      - '40000'
+      Anthropic-Ratelimit-Input-Tokens-Reset:
+      - '2025-05-23T22:12:00Z'
+      Anthropic-Ratelimit-Output-Tokens-Limit:
+      - '8000'
+      Anthropic-Ratelimit-Output-Tokens-Remaining:
+      - '7000'
+      Anthropic-Ratelimit-Output-Tokens-Reset:
+      - '2025-05-23T22:12:06Z'
+      Anthropic-Ratelimit-Requests-Limit:
+      - '50'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '49'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2025-05-23T22:12:01Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '48000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '47000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2025-05-23T22:12:00Z'
+      Request-Id:
+      - req_011CPREFCpFQV3JQEMgpXRDj
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - 89796e02-61da-4a75-b7ee-c55929f0d748
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9447e46badb602e6-GRU
+    body:
+      encoding: UTF-8
+      string: |+
+        event: message_start
+        data: {"type":"message_start","message":{"id":"msg_01Jn6oLML9WZ3nUgJdEQtZif","type":"message","role":"assistant","model":"claude-3-5-sonnet-20240620","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":74,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2,"service_tier":"standard"}}       }
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}            }
+
+        event: ping
+        data: {"type": "ping"}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"5"}     }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n10\n12"}         }
+
+        event: content_block_stop
+        data: {"type":"content_block_stop","index":0         }
+
+        event: message_delta
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":9}             }
+
+        event: message_stop
+        data: {"type":"message_stop"           }
+
+  recorded_at: Fri, 23 May 2025 22:11:41 GMT
+recorded_with: VCR 6.3.1
+...

--- a/spec/fixtures/cassettes/anthropic/chat/llm_chat_stream_tool.yml
+++ b/spec/fixtures/cassettes/anthropic/chat/llm_chat_stream_tool.yml
@@ -1,0 +1,317 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"type":"text","text":"You are
+        a bot that can run UNIX system commands"}]},{"role":"user","content":[{"type":"text","text":"Hey,
+        run the ''date'' command"}]}],"model":"claude-3-5-sonnet-20240620","max_tokens":1024,"tools":[{"name":"system","description":"Runs
+        system commands","input_schema":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}],"stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - TOKEN
+      Anthropic-Version:
+      - '2023-06-01'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 24 May 2025 13:45:25 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Anthropic-Ratelimit-Input-Tokens-Limit:
+      - '40000'
+      Anthropic-Ratelimit-Input-Tokens-Remaining:
+      - '40000'
+      Anthropic-Ratelimit-Input-Tokens-Reset:
+      - '2025-05-24T13:45:25Z'
+      Anthropic-Ratelimit-Output-Tokens-Limit:
+      - '8000'
+      Anthropic-Ratelimit-Output-Tokens-Remaining:
+      - '7000'
+      Anthropic-Ratelimit-Output-Tokens-Reset:
+      - '2025-05-24T13:45:31Z'
+      Anthropic-Ratelimit-Requests-Limit:
+      - '50'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '49'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2025-05-24T13:45:25Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '48000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '47000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2025-05-24T13:45:25Z'
+      Request-Id:
+      - req_011CPSTRYG64iv2UpwyBCYxj
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - 89796e02-61da-4a75-b7ee-c55929f0d748
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 944d3bb5fb4c00fe-GRU
+    body:
+      encoding: UTF-8
+      string: |+
+        event: message_start
+        data: {"type":"message_start","message":{"id":"msg_016kzHU2efF3EFnMCydciSFe","type":"message","role":"assistant","model":"claude-3-5-sonnet-20240620","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":372,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5,"service_tier":"standard"}}    }
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}               }
+
+        event: ping
+        data: {"type": "ping"}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Certainly! I can"}   }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" run"}           }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" the 'date'"}    }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" command for you using the"}              }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" system function. Here's"}      }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" how we'll do that"}             }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":"}          }
+
+        event: content_block_stop
+        data: {"type":"content_block_stop","index":0           }
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_016z5q6MHvMLhpBuwA4rHsw3","name":"system","input":{}}     }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}          }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\""}     }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":": \"date\"}"}     }
+
+        event: content_block_stop
+        data: {"type":"content_block_stop","index":1             }
+
+        event: message_delta
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":79}  }
+
+        event: message_stop
+        data: {"type":"message_stop"   }
+
+  recorded_at: Sat, 24 May 2025 13:45:04 GMT
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"type":"text","text":"You are
+        a bot that can run UNIX system commands"}]},{"role":"user","content":[{"type":"text","text":"Hey,
+        run the ''date'' command"}]},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_016z5q6MHvMLhpBuwA4rHsw3","name":"system","input":{"command":"date"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_016z5q6MHvMLhpBuwA4rHsw3","content":[{"type":"text","text":"{\"success\":true}"}]}]}],"model":"claude-3-5-sonnet-20240620","max_tokens":1024,"tools":[{"name":"system","description":"Runs
+        system commands","input_schema":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}],"stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - TOKEN
+      Anthropic-Version:
+      - '2023-06-01'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 24 May 2025 13:45:26 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Anthropic-Ratelimit-Input-Tokens-Limit:
+      - '40000'
+      Anthropic-Ratelimit-Input-Tokens-Remaining:
+      - '40000'
+      Anthropic-Ratelimit-Input-Tokens-Reset:
+      - '2025-05-24T13:45:26Z'
+      Anthropic-Ratelimit-Output-Tokens-Limit:
+      - '8000'
+      Anthropic-Ratelimit-Output-Tokens-Remaining:
+      - '7000'
+      Anthropic-Ratelimit-Output-Tokens-Reset:
+      - '2025-05-24T13:45:32Z'
+      Anthropic-Ratelimit-Requests-Limit:
+      - '50'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '49'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2025-05-24T13:45:27Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '48000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '47000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2025-05-24T13:45:26Z'
+      Request-Id:
+      - req_011CPSTRezeFxuU3y53eXUhk
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - 89796e02-61da-4a75-b7ee-c55929f0d748
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 944d3bc1e904a460-GRU
+    body:
+      encoding: UTF-8
+      string: |+
+        event: message_start
+        data: {"type":"message_start","message":{"id":"msg_0119FQQgafnZR32y44atUZB9","type":"message","role":"assistant","model":"claude-3-5-sonnet-20240620","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":439,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5,"service_tier":"standard"}}         }
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
+
+        event: ping
+        data: {"type": "ping"}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The 'date"}       }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"' command has been execute"}        }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d successfully. This"}}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" command displays the current date"}     }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" and time according"}          }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" to the system clock."}  }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" The"}      }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" exact"}   }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" output woul"}    }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d depend on your"}    }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" system"}}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"'s current"}               }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" date,"}       }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" time"}            }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}               }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" and timezone settings. "}   }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\nIs there anything specific"}         }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" about"}       }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" the date or"}      }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" time you'd like to"}         }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" know, or would you"}             }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" like me"}           }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" to run"}       }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" any other commands for"}            }
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" you?"}               }
+
+        event: content_block_stop
+        data: {"type":"content_block_stop","index":0 }
+
+        event: message_delta
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":77}   }
+
+        event: message_stop
+        data: {"type":"message_stop"      }
+
+  recorded_at: Sat, 24 May 2025 13:45:06 GMT
+recorded_with: VCR 6.3.1
+...

--- a/spec/fixtures/cassettes/deepseek/chat/llm_chat_stream_stringio.yml
+++ b/spec/fixtures/cassettes/deepseek/chat/llm_chat_stream_stringio.yml
@@ -1,0 +1,82 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.deepseek.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":"Keep your answers short and
+        concise, and provide three answers to the three questions. There should be
+        one answer per line. An answer should be a number, for example: 5. Nothing
+        else"},{"role":"user","content":"What is 3+2 ?"},{"role":"user","content":"What
+        is 5+5 ?"},{"role":"user","content":"What is 5+7 ?"}],"model":"deepseek-chat","stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 20 May 2025 04:26:55 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Vary:
+      - origin, access-control-request-method, access-control-request-headers
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Ds-Trace-Id:
+      - e56ff316c5ac571a0566704ec19f8b04
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=gHg2CjtXunlcAHmaXyazRLwHs.WCEbVcd4YZPgd1WJo-1747715215-1.0.1.1-dDewYn8VNB7k6_NFXVsd7RMrBV5FDo7fO4PyKnBO6pOyigEjLSsunoho8xiUDMMdM_w8ukL9g_G9pVlTMgBlCBOWcEXmXNeTbCV.qw1NQxA;
+        path=/; expires=Tue, 20-May-25 04:56:55 GMT; domain=.deepseek.com; HttpOnly;
+        Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9429141bdae1f20e-GRU
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"id":"b3ed8011-aca8-4856-a77c-e2291e76c8c2","object":"chat.completion.chunk","created":1747715215,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"b3ed8011-aca8-4856-a77c-e2291e76c8c2","object":"chat.completion.chunk","created":1747715215,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"5"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"b3ed8011-aca8-4856-a77c-e2291e76c8c2","object":"chat.completion.chunk","created":1747715215,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"  \n"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"b3ed8011-aca8-4856-a77c-e2291e76c8c2","object":"chat.completion.chunk","created":1747715215,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"10"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"b3ed8011-aca8-4856-a77c-e2291e76c8c2","object":"chat.completion.chunk","created":1747715215,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"  \n"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"b3ed8011-aca8-4856-a77c-e2291e76c8c2","object":"chat.completion.chunk","created":1747715215,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"b3ed8011-aca8-4856-a77c-e2291e76c8c2","object":"chat.completion.chunk","created":1747715215,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":""},"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":64,"completion_tokens":5,"total_tokens":69,"prompt_tokens_details":{"cached_tokens":0},"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":64}}
+
+        data: [DONE]
+
+  recorded_at: Tue, 20 May 2025 04:26:48 GMT
+recorded_with: VCR 6.3.1
+...

--- a/spec/fixtures/cassettes/deepseek/chat/llm_chat_stream_tool.yml
+++ b/spec/fixtures/cassettes/deepseek/chat/llm_chat_stream_tool.yml
@@ -1,0 +1,190 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.deepseek.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":"You are a bot that can run UNIX
+        system commands"},{"role":"user","content":"Hey, run the ''date'' command"}],"model":"deepseek-chat","tools":[{"type":"function","name":"system","function":{"name":"system","description":"Runs
+        system commands","parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}}],"stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 May 2025 00:37:07 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Vary:
+      - origin, access-control-request-method, access-control-request-headers
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Ds-Trace-Id:
+      - 86c61d0a9a3c5d760e7ad1adf4c32782
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=S11578FRLlA09jG1.L9hoHo_cNBSDoCvdZcyYi1EuEc-1747787827-1.0.1.1-woCfeGcWPtDMGnRgCqP86Ak5BOzD5PAheszWQnQPc3FKvSDh.8DJItxCVVf.RGiVkJ8OYF.Vuq1PWP3fiovCxO0hMZUi_83UNNgq3ybhUQk;
+        path=/; expires=Wed, 21-May-25 01:07:07 GMT; domain=.deepseek.com; HttpOnly;
+        Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 943000dccbf41b21-GRU
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"id":"2f880338-f251-4c9a-9b6d-2b3d7515549e","object":"chat.completion.chunk","created":1747787826,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"2f880338-f251-4c9a-9b6d-2b3d7515549e","object":"chat.completion.chunk","created":1747787826,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_0_c081498b-b2fe-4ef1-adc2-f35e8a483018","type":"function","function":{"name":"system","arguments":""}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"2f880338-f251-4c9a-9b6d-2b3d7515549e","object":"chat.completion.chunk","created":1747787826,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"2f880338-f251-4c9a-9b6d-2b3d7515549e","object":"chat.completion.chunk","created":1747787826,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"command"}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"2f880338-f251-4c9a-9b6d-2b3d7515549e","object":"chat.completion.chunk","created":1747787826,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"2f880338-f251-4c9a-9b6d-2b3d7515549e","object":"chat.completion.chunk","created":1747787826,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"date"}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"2f880338-f251-4c9a-9b6d-2b3d7515549e","object":"chat.completion.chunk","created":1747787826,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"2f880338-f251-4c9a-9b6d-2b3d7515549e","object":"chat.completion.chunk","created":1747787826,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":""},"logprobs":null,"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":115,"completion_tokens":17,"total_tokens":132,"prompt_tokens_details":{"cached_tokens":0},"prompt_cache_hit_tokens":0,"prompt_cache_miss_tokens":115}}
+
+        data: [DONE]
+
+  recorded_at: Wed, 21 May 2025 00:36:58 GMT
+- request:
+    method: post
+    uri: https://api.deepseek.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":"You are a bot that can run UNIX
+        system commands"},{"role":"user","content":"Hey, run the ''date'' command"},{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_0_c081498b-b2fe-4ef1-adc2-f35e8a483018","type":"function","function":{"name":"system","arguments":"{\"command\":\"date\"}"}}]},{"role":"tool","tool_call_id":"call_0_c081498b-b2fe-4ef1-adc2-f35e8a483018","content":"{\"success\":true}"}],"model":"deepseek-chat","tools":[{"type":"function","name":"system","function":{"name":"system","description":"Runs
+        system commands","parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}}],"stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 21 May 2025 00:37:12 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Vary:
+      - origin, access-control-request-method, access-control-request-headers
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Ds-Trace-Id:
+      - 6669fbb98087819b2f658f25bda06e1f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=oJJH2gRTVRAU4uEhGrFUDp_F8SDe5hSjN2va7OWnm0k-1747787832-1.0.1.1-.S0S8M4QHDuOuEfNik4NSxAVCLaU1pLHRZzyM0wbRw9OkVj37zORo5j_Rw0uT7ONzDSTFBlJg1O7QxQJ32F59WmqbleejnCouy2uwazY3xE;
+        path=/; expires=Wed, 21-May-25 01:07:12 GMT; domain=.deepseek.com; HttpOnly;
+        Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 943000fc29449615-GRU
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" current"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" date"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" and"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" time"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" is"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" Fri"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" Oct"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"27"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"34"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"56"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" UTC"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"202"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":"3"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"ed5f982a-5bbe-4e12-b0cb-d5e78f65d976","object":"chat.completion.chunk","created":1747787832,"model":"deepseek-chat","system_fingerprint":"fp_8802369eaa_prod0425fp8","choices":[{"index":0,"delta":{"content":""},"logprobs":null,"finish_reason":"stop"}],"usage":{"prompt_tokens":142,"completion_tokens":21,"total_tokens":163,"prompt_tokens_details":{"cached_tokens":128},"prompt_cache_hit_tokens":128,"prompt_cache_miss_tokens":14}}
+
+        data: [DONE]
+
+  recorded_at: Wed, 21 May 2025 00:37:06 GMT
+recorded_with: VCR 6.3.1
+...

--- a/spec/fixtures/cassettes/gemini/chat/llm_chat_stream_stringio.yml
+++ b/spec/fixtures/cassettes/gemini/chat/llm_chat_stream_stringio.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse&key=TOKEN
+    body:
+      encoding: UTF-8
+      string: '{"contents":[{"role":"user","parts":[{"text":"Keep your answers short
+        and concise, and provide three answers to the three questions. There should
+        be one answer per line. An answer should be a number, for example: 5. Nothing
+        else"}]},{"role":"user","parts":[{"text":"What is 3+2 ?"}]},{"role":"user","parts":[{"text":"What
+        is 5+5 ?"}]},{"role":"user","parts":[{"text":"What is 5+7 ?"}]}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/event-stream
+      Content-Disposition:
+      - attachment
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Sat, 24 May 2025 17:44:35 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - gfet4t7; dur=1083
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+    body:
+      encoding: UTF-8
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"5\"}],\"role\":
+        \"model\"}}],\"usageMetadata\": {\"promptTokenCount\": 64,\"totalTokenCount\":
+        64,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 64}]},\"modelVersion\":
+        \"gemini-1.5-flash\",\"responseId\": \"gwUyaLHECPuh7dcP2IubgAc\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\\n10\\n12\\n\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\"}],\"usageMetadata\": {\"promptTokenCount\":
+        60,\"candidatesTokenCount\": 8,\"totalTokenCount\": 68,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 60}],\"candidatesTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 8}]},\"modelVersion\": \"gemini-1.5-flash\",\"responseId\":
+        \"gwUyaLHECPuh7dcP2IubgAc\"}\r\n\r\n"
+  recorded_at: Sat, 24 May 2025 17:44:13 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/gemini/chat/llm_chat_stream_tool.yml
+++ b/spec/fixtures/cassettes/gemini/chat/llm_chat_stream_tool.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse&key=TOKEN
+    body:
+      encoding: UTF-8
+      string: '{"contents":[{"role":"user","parts":[{"text":"You are a bot that can
+        run UNIX system commands"}]},{"role":"user","parts":[{"text":"Hey, run the
+        ''date'' command"}]}],"tools":{"functionDeclarations":[{"name":"system","description":"Runs
+        system commands","parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}]}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/event-stream
+      Content-Disposition:
+      - attachment
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Sat, 24 May 2025 19:02:05 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - gfet4t7; dur=1236
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+    body:
+      encoding: UTF-8
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
+        {\"name\": \"system\",\"args\": {\"command\": \"date\"}}}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\"}],\"usageMetadata\": {\"promptTokenCount\": 26,\"candidatesTokenCount\":
+        3,\"totalTokenCount\": 29,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        26}],\"candidatesTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        3}]},\"modelVersion\": \"gemini-1.5-flash\",\"responseId\": \"rBcyaJ-SN4iT7dcPq42tuAY\"}\r\n\r\n"
+  recorded_at: Sat, 24 May 2025 19:01:43 GMT
+- request:
+    method: post
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse&key=TOKEN
+    body:
+      encoding: UTF-8
+      string: '{"contents":[{"role":"user","parts":[{"text":"You are a bot that can
+        run UNIX system commands"}]},{"role":"user","parts":[{"text":"Hey, run the
+        ''date'' command"}]},{"role":"model","parts":[{"functionCall":{"name":"system","args":{"command":"date"}}}]},{"role":"user","parts":[{"text":"{\"success\":true}"}]}],"tools":{"functionDeclarations":[{"name":"system","description":"Runs
+        system commands","parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}]}}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/event-stream
+      Content-Disposition:
+      - attachment
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Sat, 24 May 2025 19:02:06 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Server-Timing:
+      - gfet4t7; dur=1095
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+    body:
+      encoding: UTF-8
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"OK\"}],\"role\":
+        \"model\"}}],\"usageMetadata\": {\"promptTokenCount\": 73,\"totalTokenCount\":
+        73,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 73}]},\"modelVersion\":
+        \"gemini-1.5-flash\",\"responseId\": \"rhcyaM72EfyQ7dcPhLua8AU\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \".  The date command
+        executed successfully.  Do you have any other commands you\"}],\"role\": \"model\"}}],\"usageMetadata\":
+        {\"promptTokenCount\": 73,\"totalTokenCount\": 73,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 73}]},\"modelVersion\": \"gemini-1.5-flash\",\"responseId\":
+        \"rhcyaM72EfyQ7dcPhLua8AU\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
+        {\"parts\": [{\"text\": \" would like me to run?\\n\"}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\"}],\"usageMetadata\": {\"promptTokenCount\": 34,\"candidatesTokenCount\":
+        24,\"totalTokenCount\": 58,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        34}],\"candidatesTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        24}]},\"modelVersion\": \"gemini-1.5-flash\",\"responseId\": \"rhcyaM72EfyQ7dcPhLua8AU\"}\r\n\r\n"
+  recorded_at: Sat, 24 May 2025 19:01:44 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/llamacpp/chat/llm_chat_stream_stringio.yml
+++ b/spec/fixtures/cassettes/llamacpp/chat/llm_chat_stream_stringio.yml
@@ -1,0 +1,383 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"type":"text","text":"Keep
+        your answers short and concise, and provide three answers to the three questions.
+        There should be one answer per line. An answer should be a number, for example:
+        5. Nothing else"}]},{"role":"user","content":[{"type":"text","text":"What
+        is 3+2 ?"}]},{"role":"user","content":[{"type":"text","text":"What is 5+5
+        ?"}]},{"role":"user","content":[{"type":"text","text":"What is 5+7 ?"}]}],"model":"qwen3","stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Keep-Alive:
+      - timeout=5, max=100
+      Content-Type:
+      - text/event-stream
+      Server:
+      - llama.cpp
+      Transfer-Encoding:
+      - chunked
+      Access-Control-Allow-Origin:
+      - ''
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"<think>"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"\n"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"Okay"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":","}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" the"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" user"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" wants"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" me"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" to"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" answer"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" three"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" math"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" questions"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" with"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" just"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" numbers"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" Let"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" me"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" check"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" each"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" one"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":".\n\n"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"First"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" question"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":":"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"3"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" +"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"2"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" That"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"'s"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" straightforward"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"3"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" plus"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"2"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" is"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"5"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" I"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"'ll"}}],"created":1747707989,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" write"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"5"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":".\n\n"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"Second"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" question"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":":"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"5"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" +"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"5"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" Adding"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" those"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" together"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" gives"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"1"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"0"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" So"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" the"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" answer"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" is"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"1"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"0"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":".\n\n"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"Third"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" question"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":":"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"5"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" +"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"7"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" Hmm"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":","}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"5"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" plus"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"7"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" equals"}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707990,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"1"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"2"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" I"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" need"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" to"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" make"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" sure"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" I"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" didn"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"'t"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" mix"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" up"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" the"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" numbers"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" Yep"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":","}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"5"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"+"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"7"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" is"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" definitely"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" "}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"1"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"2"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":".\n\n"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"Wait"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":","}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" the"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" user"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" said"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" one"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" answer"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" per"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" line"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" and"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" keep"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" it"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" concise"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" Let"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" me"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" make"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" sure"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" each"}}],"created":1747707991,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" answer"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" is"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" just"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" the"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" number"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" and"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" nothing"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" else"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"."}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" Alright"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":","}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" that"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"'s"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":" all"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":".\n"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"</think>"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"\n\n"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"5"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"  \n"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"1"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"0"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"  \n"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"1"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":"2"}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":null,"index":0,"delta":{"content":""}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk"}
+
+        data: {"choices":[{"finish_reason":"stop","index":0,"delta":{}}],"created":1747707992,"id":"chatcmpl-IHbua5GWKJ8V8HEwDZCEkw2TngFFe1bQ","model":"qwen3","system_fingerprint":"b5379-360a9c98","object":"chat.completion.chunk","usage":{"completion_tokens":166,"prompt_tokens":83,"total_tokens":249},"timings":{"prompt_n":83,"prompt_ms":68.93,"prompt_per_token_ms":0.8304819277108435,"prompt_per_second":1204.120121862759,"predicted_n":166,"predicted_ms":3518.851,"predicted_per_token_ms":21.197897590361446,"predicted_per_second":47.17448962743804},"__verbose":{"index":0,"content":"","tokens":[],"id_slot":0,"stop":true,"model":"qwen3","tokens_predicted":166,"tokens_evaluated":83,"generation_settings":{"n_predict":-1,"seed":4294967295,"temperature":0.800000011920929,"dynatemp_range":0.0,"dynatemp_exponent":1.0,"top_k":40,"top_p":0.949999988079071,"min_p":0.05000000074505806,"top_n_sigma":-1.0,"xtc_probability":0.0,"xtc_threshold":0.10000000149011612,"typical_p":1.0,"repeat_last_n":64,"repeat_penalty":1.0,"presence_penalty":0.0,"frequency_penalty":0.0,"dry_multiplier":0.0,"dry_base":1.75,"dry_allowed_length":2,"dry_penalty_last_n":4096,"dry_sequence_breakers":["\n",":","\"","*"],"mirostat":0,"mirostat_tau":5.0,"mirostat_eta":0.10000000149011612,"stop":[],"max_tokens":-1,"n_keep":0,"n_discard":0,"ignore_eos":false,"stream":true,"logit_bias":[],"n_probs":0,"min_keep":0,"grammar":"","grammar_lazy":false,"grammar_triggers":[],"preserved_tokens":[],"chat_format":"Content-only","samplers":["penalties","dry","top_n_sigma","top_k","typ_p","top_p","min_p","xtc","temperature"],"speculative.n_max":16,"speculative.n_min":0,"speculative.p_min":0.75,"timings_per_token":false,"post_sampling_probs":false,"lora":[]},"prompt":"<|im_start|>user\nKeep your answers short and concise, and provide three answers to the three questions. There should be one answer per line. An answer should be a number, for example: 5. Nothing else<|im_end|>\n<|im_start|>user\nWhat is 3+2 ?<|im_end|>\n<|im_start|>user\nWhat is 5+5 ?<|im_end|>\n<|im_start|>user\nWhat is 5+7 ?<|im_end|>\n<|im_start|>assistant\n","has_new_line":true,"truncated":false,"stop_type":"eos","stopping_word":"","tokens_cached":248,"timings":{"prompt_n":83,"prompt_ms":68.93,"prompt_per_token_ms":0.8304819277108435,"prompt_per_second":1204.120121862759,"predicted_n":166,"predicted_ms":3518.851,"predicted_per_token_ms":21.197897590361446,"predicted_per_second":47.17448962743804}}}
+
+        data: [DONE]
+
+  recorded_at: Tue, 20 May 2025 02:26:22 GMT
+recorded_with: VCR 6.3.1
+...

--- a/spec/fixtures/cassettes/llamacpp/chat/llm_chat_stream_tool.yml
+++ b/spec/fixtures/cassettes/llamacpp/chat/llm_chat_stream_tool.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8080/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"type":"text","text":"You are
+        a bot that can run UNIX system commands"}]},{"role":"user","content":[{"type":"text","text":"Hey,
+        run the ''date'' command"}]}],"model":"qwen3","tools":[{"type":"function","name":"system","function":{"name":"system","description":"Runs
+        system commands","parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}}],"stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Keep-Alive:
+      - timeout=5, max=100
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - llama.cpp
+      Content-Length:
+      - '85'
+      Access-Control-Allow-Origin:
+      - ''
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":500,"message":"Cannot use tools with stream","type":"server_error"}}'
+  recorded_at: Wed, 21 May 2025 01:13:23 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/ollama/chat/llm_chat_stream_stringio.yml
+++ b/spec/fixtures/cassettes/ollama/chat/llm_chat_stream_stringio.yml
@@ -1,0 +1,223 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:11434/api/chat
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":"Keep your answers short and
+        concise, and provide three answers to the three questions. There should be
+        one answer per line. An answer should be a number, for example: 5. Nothing
+        else"},{"role":"user","content":"What is 3+2 ?"},{"role":"user","content":"What
+        is 5+5 ?"},{"role":"user","content":"What is 5+7 ?"}],"model":"qwen3:latest","stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/x-ndjson
+      Date:
+      - Mon, 26 May 2025 18:17:38 GMT
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.545458283Z","message":{"role":"assistant","content":"\u003cthink\u003e"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.580447354Z","message":{"role":"assistant","content":"\n"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.601009481Z","message":{"role":"assistant","content":"Okay"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.621399212Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.641819973Z","message":{"role":"assistant","content":" let"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.662229394Z","message":{"role":"assistant","content":"'s"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.682638324Z","message":{"role":"assistant","content":" see"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.703040808Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.723484698Z","message":{"role":"assistant","content":" The"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.743899905Z","message":{"role":"assistant","content":" user"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.764307652Z","message":{"role":"assistant","content":" wants"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.784701463Z","message":{"role":"assistant","content":" three"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.80512826Z","message":{"role":"assistant","content":" answers"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.825545281Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.845950622Z","message":{"role":"assistant","content":" each"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.86635109Z","message":{"role":"assistant","content":" on"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.886777876Z","message":{"role":"assistant","content":" a"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.907217546Z","message":{"role":"assistant","content":" separate"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.927589039Z","message":{"role":"assistant","content":" line"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.94800989Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.968421247Z","message":{"role":"assistant","content":" and"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:38.988840464Z","message":{"role":"assistant","content":" each"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.009235317Z","message":{"role":"assistant","content":" should"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.029659146Z","message":{"role":"assistant","content":" be"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.050087106Z","message":{"role":"assistant","content":" a"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.070497971Z","message":{"role":"assistant","content":" number"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.090924737Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.111301875Z","message":{"role":"assistant","content":" The"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.133672945Z","message":{"role":"assistant","content":" questions"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.154190637Z","message":{"role":"assistant","content":" are"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.174656736Z","message":{"role":"assistant","content":" straightforward"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.195167109Z","message":{"role":"assistant","content":" arithmetic"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.215619783Z","message":{"role":"assistant","content":" problems"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.236139901Z","message":{"role":"assistant","content":".\n\n"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.256608817Z","message":{"role":"assistant","content":"First"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.277102798Z","message":{"role":"assistant","content":" question"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.297587465Z","message":{"role":"assistant","content":":"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.318088093Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.33860371Z","message":{"role":"assistant","content":"3"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.359103907Z","message":{"role":"assistant","content":" +"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.379613758Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.400079285Z","message":{"role":"assistant","content":"2"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.420684766Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.441117227Z","message":{"role":"assistant","content":" That"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.461619058Z","message":{"role":"assistant","content":"'s"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.482186219Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.502624465Z","message":{"role":"assistant","content":"5"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.523087014Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.54358282Z","message":{"role":"assistant","content":" Easy"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.564097444Z","message":{"role":"assistant","content":" enough"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.584606333Z","message":{"role":"assistant","content":".\n\n"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.605123945Z","message":{"role":"assistant","content":"Second"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.625620543Z","message":{"role":"assistant","content":" question"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.646106493Z","message":{"role":"assistant","content":":"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.666600805Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.687089351Z","message":{"role":"assistant","content":"5"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.707585829Z","message":{"role":"assistant","content":" +"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.728088462Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.748585791Z","message":{"role":"assistant","content":"5"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.769084565Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.790427848Z","message":{"role":"assistant","content":" That"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.811064459Z","message":{"role":"assistant","content":" equals"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.831686552Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.852338102Z","message":{"role":"assistant","content":"1"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.872963463Z","message":{"role":"assistant","content":"0"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.893624277Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.914226739Z","message":{"role":"assistant","content":" No"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.934859109Z","message":{"role":"assistant","content":" issues"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.956353725Z","message":{"role":"assistant","content":" there"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.977829603Z","message":{"role":"assistant","content":".\n\n"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:39.998461953Z","message":{"role":"assistant","content":"Third"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.019107036Z","message":{"role":"assistant","content":" question"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.039763909Z","message":{"role":"assistant","content":":"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.060382603Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.080988885Z","message":{"role":"assistant","content":"5"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.101625065Z","message":{"role":"assistant","content":" +"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.122244782Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.142877322Z","message":{"role":"assistant","content":"7"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.163513562Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.184157552Z","message":{"role":"assistant","content":" Hmm"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.204845326Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.225408736Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.246039612Z","message":{"role":"assistant","content":"5"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.26666743Z","message":{"role":"assistant","content":" plus"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.287300933Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.307935819Z","message":{"role":"assistant","content":"7"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.328591439Z","message":{"role":"assistant","content":" is"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.349202614Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.369844529Z","message":{"role":"assistant","content":"1"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.390482784Z","message":{"role":"assistant","content":"2"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.411111755Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.431741558Z","message":{"role":"assistant","content":" Wait"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.453317134Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.474008046Z","message":{"role":"assistant","content":" is"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.494683858Z","message":{"role":"assistant","content":" that"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.515355039Z","message":{"role":"assistant","content":" right"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.536021256Z","message":{"role":"assistant","content":"?"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.55670921Z","message":{"role":"assistant","content":" Let"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.577379569Z","message":{"role":"assistant","content":" me"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.598044433Z","message":{"role":"assistant","content":" check"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.61874506Z","message":{"role":"assistant","content":" again"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.639415298Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.660081345Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.680773028Z","message":{"role":"assistant","content":"5"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.701465053Z","message":{"role":"assistant","content":" +"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.722151393Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.742792676Z","message":{"role":"assistant","content":"7"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.76347679Z","message":{"role":"assistant","content":"..."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.784174389Z","message":{"role":"assistant","content":" yeah"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.804846491Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.825514734Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.846192161Z","message":{"role":"assistant","content":"1"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.86688583Z","message":{"role":"assistant","content":"2"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.887562204Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.908221082Z","message":{"role":"assistant","content":" Okay"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.928926792Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.949595005Z","message":{"role":"assistant","content":" that"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.970263809Z","message":{"role":"assistant","content":"'s"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:40.990952645Z","message":{"role":"assistant","content":" correct"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.011616647Z","message":{"role":"assistant","content":".\n\n"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.033141011Z","message":{"role":"assistant","content":"I"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.05396189Z","message":{"role":"assistant","content":" need"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.074759358Z","message":{"role":"assistant","content":" to"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.095456305Z","message":{"role":"assistant","content":" make"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.118305585Z","message":{"role":"assistant","content":" sure"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.139084505Z","message":{"role":"assistant","content":" each"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.159849118Z","message":{"role":"assistant","content":" answer"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.180593218Z","message":{"role":"assistant","content":" is"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.201370724Z","message":{"role":"assistant","content":" just"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.222136229Z","message":{"role":"assistant","content":" the"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.24290392Z","message":{"role":"assistant","content":" number"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.263664683Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.284452295Z","message":{"role":"assistant","content":" no"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.305207283Z","message":{"role":"assistant","content":" extra"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.325963624Z","message":{"role":"assistant","content":" text"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.346759488Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.367517694Z","message":{"role":"assistant","content":" So"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.388282808Z","message":{"role":"assistant","content":" the"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.409044614Z","message":{"role":"assistant","content":" answers"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.429817959Z","message":{"role":"assistant","content":" should"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.450579725Z","message":{"role":"assistant","content":" be"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.471348619Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.492146859Z","message":{"role":"assistant","content":"5"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.512898919Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.533665036Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.554430641Z","message":{"role":"assistant","content":"1"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.575179904Z","message":{"role":"assistant","content":"0"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.59595344Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.616759861Z","message":{"role":"assistant","content":" "},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.637489143Z","message":{"role":"assistant","content":"1"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.658242436Z","message":{"role":"assistant","content":"2"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.679002327Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.699764333Z","message":{"role":"assistant","content":" Each"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.720536284Z","message":{"role":"assistant","content":" on"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.741305229Z","message":{"role":"assistant","content":" their"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.762081241Z","message":{"role":"assistant","content":" own"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.783972857Z","message":{"role":"assistant","content":" line"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.804767137Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.825603205Z","message":{"role":"assistant","content":" That"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.846413587Z","message":{"role":"assistant","content":"'s"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.867228329Z","message":{"role":"assistant","content":" all"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.887996461Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.908804928Z","message":{"role":"assistant","content":" No"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.929625917Z","message":{"role":"assistant","content":" explanations"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.950411564Z","message":{"role":"assistant","content":","},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.971224452Z","message":{"role":"assistant","content":" just"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:41.992030954Z","message":{"role":"assistant","content":" the"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.0128431Z","message":{"role":"assistant","content":" numbers"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.033666956Z","message":{"role":"assistant","content":"."},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.054498363Z","message":{"role":"assistant","content":" Got"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.075301716Z","message":{"role":"assistant","content":" it"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.096101871Z","message":{"role":"assistant","content":".\n"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.116910127Z","message":{"role":"assistant","content":"\u003c/think\u003e"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.137714623Z","message":{"role":"assistant","content":"\n\n"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.158539933Z","message":{"role":"assistant","content":"5"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.179325671Z","message":{"role":"assistant","content":"  \n"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.200118437Z","message":{"role":"assistant","content":"1"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.220942113Z","message":{"role":"assistant","content":"0"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.241748223Z","message":{"role":"assistant","content":"  \n"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.262538643Z","message":{"role":"assistant","content":"1"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.283336743Z","message":{"role":"assistant","content":"2"},"done":false}
+        {"model":"qwen3:latest","created_at":"2025-05-26T18:17:42.304184401Z","message":{"role":"assistant","content":""},"done_reason":"stop","done":true,"total_duration":27122697290,"load_duration":23001819882,"prompt_eval_count":69,"prompt_eval_duration":355553555,"eval_count":182,"eval_duration":3761362317}
+  recorded_at: Mon, 26 May 2025 18:17:15 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/openai/chat/llm_chat_stream_stringio.yml
+++ b/spec/fixtures/cassettes/openai/chat/llm_chat_stream_stringio.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"type":"text","text":"Keep
+        your answers short and concise, and provide three answers to the three questions.
+        There should be one answer per line. An answer should be a number, for example:
+        5. Nothing else"}]},{"role":"user","content":[{"type":"text","text":"What
+        is 3+2 ?"}]},{"role":"user","content":[{"type":"text","text":"What is 5+5
+        ?"}]},{"role":"user","content":[{"type":"text","text":"What is 5+7 ?"}]}],"model":"gpt-4o-mini","stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 19 May 2025 22:39:45 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Processing-Ms:
+      - '205'
+      Openai-Version:
+      - '2020-10-01'
+      X-Envoy-Upstream-Service-Time:
+      - '210'
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '199938'
+      X-Ratelimit-Reset-Requests:
+      - 8.64s
+      X-Ratelimit-Reset-Tokens:
+      - 18ms
+      X-Request-Id:
+      - req_2e6754a344788f1fb271650264a39a78
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=qddgY55PHO5_nJlDW1KSkNDUQM.blKQ33QjXSWht5Rk-1747694385-1.0.1.1-MBFOUgOSu_pGdaMsHO0cK3hvQBTjNwghQYTNC0cpZVkGPfGS3F7ttFC8C8wCSsYeZtHqhph5x75Q43wQ08I9QlmvS7QDGw8dY9.Cm4AZHq4;
+        path=/; expires=Mon, 19-May-25 23:09:45 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=Nuvvk7PlC0UYlWBl0n7OQWUKcxi2KW8bLaDn_TCzJ5E-1747694385560-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 942717911fecf202-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"id":"chatcmpl-BZ3R3sAa17EV6ONrfvNra0ajSiLkZ","object":"chat.completion.chunk","created":1747694385,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_0392822090","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZ3R3sAa17EV6ONrfvNra0ajSiLkZ","object":"chat.completion.chunk","created":1747694385,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_0392822090","choices":[{"index":0,"delta":{"content":"5"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZ3R3sAa17EV6ONrfvNra0ajSiLkZ","object":"chat.completion.chunk","created":1747694385,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_0392822090","choices":[{"index":0,"delta":{"content":"  \n"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZ3R3sAa17EV6ONrfvNra0ajSiLkZ","object":"chat.completion.chunk","created":1747694385,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_0392822090","choices":[{"index":0,"delta":{"content":"10"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZ3R3sAa17EV6ONrfvNra0ajSiLkZ","object":"chat.completion.chunk","created":1747694385,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_0392822090","choices":[{"index":0,"delta":{"content":"  \n"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZ3R3sAa17EV6ONrfvNra0ajSiLkZ","object":"chat.completion.chunk","created":1747694385,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_0392822090","choices":[{"index":0,"delta":{"content":"12"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZ3R3sAa17EV6ONrfvNra0ajSiLkZ","object":"chat.completion.chunk","created":1747694385,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_0392822090","choices":[{"index":0,"delta":{"content":"  "},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZ3R3sAa17EV6ONrfvNra0ajSiLkZ","object":"chat.completion.chunk","created":1747694385,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_0392822090","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+        data: [DONE]
+
+  recorded_at: Mon, 19 May 2025 22:39:35 GMT
+recorded_with: VCR 6.3.1
+...

--- a/spec/fixtures/cassettes/openai/chat/llm_chat_stream_tool.yml
+++ b/spec/fixtures/cassettes/openai/chat/llm_chat_stream_tool.yml
@@ -1,0 +1,270 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"type":"text","text":"You are
+        a bot that can run UNIX system commands"}]},{"role":"user","content":[{"type":"text","text":"Hey,
+        run the ''date'' command"}]}],"model":"gpt-4o-mini","tools":[{"type":"function","name":"system","function":{"name":"system","description":"Runs
+        system commands","parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}}],"stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 20 May 2025 22:44:13 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Processing-Ms:
+      - '407'
+      Openai-Version:
+      - '2020-10-01'
+      X-Envoy-Upstream-Service-Time:
+      - '416'
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '199977'
+      X-Ratelimit-Reset-Requests:
+      - 8.64s
+      X-Ratelimit-Reset-Tokens:
+      - 6ms
+      X-Request-Id:
+      - req_b68e40c6f843872396ea8eba8e5453d2
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=rFJMlw5XzXqce7cYNWfyDcJJHlkeI_eA0eF2HvcbrrI-1747781053-1.0.1.1-yEcE_2m4Qyxgm0pkgKY7P_3gu2qrmcWDpL8vjL5EHzfOEoOSRzZ2P03lbKClPBxsbdf2gGMZtEZVujMA2WuzAq7H2zDYjtslKP3oxALo.5A;
+        path=/; expires=Tue, 20-May-25 23:14:13 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=LT4Aj6LDDfYn0R41C1Y.AbwW2s6hU4acDWbpocJV.Rw-1747781053677-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 942f5b7d3b221ab1-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"id":"chatcmpl-BZPyvP2hRGXn5joVcr155TNXkijJ5","object":"chat.completion.chunk","created":1747781053,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_J6wxqjgho8e5JTZdcrMF7VPd","type":"function","function":{"name":"system","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPyvP2hRGXn5joVcr155TNXkijJ5","object":"chat.completion.chunk","created":1747781053,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPyvP2hRGXn5joVcr155TNXkijJ5","object":"chat.completion.chunk","created":1747781053,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"command"}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPyvP2hRGXn5joVcr155TNXkijJ5","object":"chat.completion.chunk","created":1747781053,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPyvP2hRGXn5joVcr155TNXkijJ5","object":"chat.completion.chunk","created":1747781053,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"date"}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPyvP2hRGXn5joVcr155TNXkijJ5","object":"chat.completion.chunk","created":1747781053,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPyvP2hRGXn5joVcr155TNXkijJ5","object":"chat.completion.chunk","created":1747781053,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}]}
+
+        data: [DONE]
+
+  recorded_at: Tue, 20 May 2025 22:44:01 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"type":"text","text":"You are
+        a bot that can run UNIX system commands"}]},{"role":"user","content":[{"type":"text","text":"Hey,
+        run the ''date'' command"}]},{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_J6wxqjgho8e5JTZdcrMF7VPd","type":"function","function":{"name":"system","arguments":"{\"command\":\"date\"}"}}]},{"role":"tool","tool_call_id":"call_J6wxqjgho8e5JTZdcrMF7VPd","content":"{\"success\":true}"}],"model":"gpt-4o-mini","tools":[{"type":"function","name":"system","function":{"name":"system","description":"Runs
+        system commands","parameters":{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}}}],"stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 20 May 2025 22:44:14 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Processing-Ms:
+      - '355'
+      Openai-Version:
+      - '2020-10-01'
+      X-Envoy-Upstream-Service-Time:
+      - '372'
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '9998'
+      X-Ratelimit-Remaining-Tokens:
+      - '199972'
+      X-Ratelimit-Reset-Requests:
+      - 16.563s
+      X-Ratelimit-Reset-Tokens:
+      - 8ms
+      X-Request-Id:
+      - req_a5195746a8ecc2fc9c568d4b72f7d508
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=.f.gl1sCsHGYJJXFi3w7TdvGxiv2xJFqkgjZSgxkWrk-1747781054-1.0.1.1-MOChBcIQaGsczf2JfV1700Aa3j7waGbJ3_9QnB12JGQL._PWBOAi8C23ITHD1FAceAU9C0RXjsXmPXZxagNXn9mDveRZ9nn4gnuM9fWtNOs;
+        path=/; expires=Tue, 20-May-25 23:14:14 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=If3yT22tPvDpj2i7CQHzngBzPVt4IyM4UJkdFHqfzcs-1747781054334-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 942f5b82481cf1d5-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" command"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" was"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" executed"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" successfully"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" However"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" I"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" don't"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" have"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" the"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" ability"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" to"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" display"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" the"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" output"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" directly"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" You"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" can"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" try"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" running"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" the"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" `"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"date"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"`"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" command"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" in"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" your"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" own"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" UNIX"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" terminal"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" to"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" see"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" the"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" current"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" date"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" and"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":" time"},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}]}
+
+        data: {"id":"chatcmpl-BZPywKkK5Yf3cHkUH069vRe2gZ4f3","object":"chat.completion.chunk","created":1747781054,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_54eb4bd693","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}]}
+
+        data: [DONE]
+
+  recorded_at: Tue, 20 May 2025 22:44:02 GMT
+recorded_with: VCR 6.3.1
+...

--- a/spec/gemini/chat_spec.rb
+++ b/spec/gemini/chat_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "LLM::Chat: gemini" do
 
   context LLM::Chat do
     include_examples "LLM::Chat: completions", :gemini, match_requests_on: [:method]
+    include_examples "LLM::Chat: text stream", :gemini, match_requests_on: [:method]
+    include_examples "LLM::Chat: tool stream", :gemini, match_requests_on: [:method]
   end
 
   context LLM::Function do

--- a/spec/llamacpp/chat_spec.rb
+++ b/spec/llamacpp/chat_spec.rb
@@ -8,9 +8,34 @@ RSpec.describe "LLM::Chat: llamacpp" do
   let(:host) { ENV["LLAMACPP_HOST"] || "localhost" }
   let(:bot) { described_class.new(provider, params.merge(model: "qwen3")).lazy }
   let(:params) { {} }
+  vcr = lambda { {vcr: {cassette_name: "llamacpp/chat/#{_1}"}} }
 
   context LLM::Chat do
     include_examples "LLM::Chat: completions", :llamacpp
+
+    context "with streams" do
+      include_examples "LLM::Chat: text stream", :llamacpp
+
+      context "when tool calls are not supported", vcr.call("llm_chat_stream_tool") do
+        before { bot.chat "Run the tool" }
+
+        let(:params) { {stream: true, tools: [tool]} }
+        let(:tool) do
+          LLM.function(:system) do |fn|
+            fn.description "Runs system commands"
+            fn.params { _1.object(command: _1.string.required) }
+            fn.define { {success: Kernel.system(_1.command)} }
+          end
+        end
+
+        it "emits an error" do
+          bot.messages.to_a
+          expect(false).to be_true
+        rescue => ex
+          expect(ex.message).to match(/Cannot use tools with stream/)
+        end
+      end
+    end
   end
 
   context LLM::Function do

--- a/spec/ollama/chat_spec.rb
+++ b/spec/ollama/chat_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "LLM::Chat: ollama" do
 
   context LLM::Chat do
     include_examples "LLM::Chat: completions", :ollama
+    include_examples "LLM::Chat: text stream", :ollama
   end
 
   context LLM::Function do

--- a/spec/openai/chat_spec.rb
+++ b/spec/openai/chat_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "LLM::Chat: openai" do
 
   context LLM::Chat do
     include_examples "LLM::Chat: completions", :openai
+    include_examples "LLM::Chat: text stream", :openai
+    include_examples "LLM::Chat: tool stream", :openai
   end
 
   context LLM::Function do

--- a/spec/support/shared_examples/llm_chat_stream.rb
+++ b/spec/support/shared_examples/llm_chat_stream.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "LLM::Chat: text stream" do |dirname, options = {}|
+  vcr = lambda do |basename|
+    {vcr: {cassette_name: "#{dirname}/chat/#{basename}"}.merge(options)}
+  end
+
+  context "when given an IO stream", vcr.call("llm_chat_stream_stringio") do
+    let(:params) { {stream:} }
+    let(:stream) { StringIO.new }
+    let(:system_prompt) do
+      "Keep your answers short and concise, and provide three answers to the three questions. " \
+      "There should be one answer per line. " \
+      "An answer should be a number, for example: 5. " \
+      "Nothing else"
+    end
+
+    before do
+      bot.chat do |prompt|
+        prompt.user system_prompt
+        prompt.user "What is 3+2 ?"
+        prompt.user "What is 5+5 ?"
+        prompt.user "What is 5+7 ?"
+      end.to_a
+    end
+
+    context "with the contents of the IO" do
+      subject { stream.string }
+      it { is_expected.to match(%r_5\s*\n10\s*\n12\s*_) }
+    end
+
+    context "with the contents of the message" do
+      subject { bot.messages.find(&:assistant?) }
+      it { is_expected.to have_attributes(role: %r_(assistant|model)_, content: %r_5\s*\n10\s*\n12\s*_ ) }
+    end
+  end
+end
+
+RSpec.shared_examples "LLM::Chat: tool stream" do |dirname, options = {}|
+  vcr = lambda do |basename|
+    {vcr: {cassette_name: "#{dirname}/chat/#{basename}"}.merge(options)}
+  end
+
+  context "when given a tool call", vcr.call("llm_chat_stream_tool") do
+    let(:params) { {stream: true, tools: [tool]} }
+    let(:tool) do
+      LLM.function(:system) do |fn|
+        fn.description "Runs system commands"
+        fn.params { _1.object(command: _1.string.required) }
+        fn.define { {success: Kernel.system(_1.command)} }
+      end
+    end
+    before do
+      bot.chat("You are a bot that can run UNIX system commands", role: :user)
+      bot.chat("Hey, run the 'date' command", role: :user)
+    end
+
+    it "calls the function" do
+      expect(Kernel).to receive(:system).with("date").and_return(true)
+      bot.chat bot.functions[0].call
+      expect(bot.functions).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
This change reaches a milestone in llm.rb's journey with support 
finally added for streaming. All providers are supported, and streaming 
is implemented on top of Server-Side Events (SSE).  We expect that the 
interface will evolve over time to support yielding a message to a Proc 
but for now you can stream to an IO-like object, or enable streaming 
without an IO object