### PR TITLE
openai: extend Vector Stores support

### DIFF
--- a/lib/llm/providers/openai/vector_stores.rb
+++ b/lib/llm/providers/openai/vector_stores.rb
@@ -96,6 +96,89 @@ class LLM::OpenAI
       LLM::Response.new(res)
     end
 
+    ##
+    # List all files in a vector store
+    # @param [String, #id] vector The ID of the vector store
+    # @param [Hash] params Other parameters (see OpenAI docs)
+    # @raise (see LLM::Provider#request)
+    # @return [LLM::Response]
+    # @see https://platform.openai.com/docs/api-reference/vector_stores_files/listFiles OpenAI docs
+    def all_files(vector:, **params)
+      vector_id = vector.respond_to?(:id) ? vector.id : vector
+      query = URI.encode_www_form(params)
+      req = Net::HTTP::Get.new("/v1/vector_stores/#{vector_id}/files?#{query}", headers)
+      res = execute(request: req)
+      LLM::Response.new(res)
+    end
+
+    ##
+    # Add a file to a vector store
+    # @param [String, #id] vector The ID of the vector store
+    # @param [String, #id] file The ID of the file to add
+    # @param [Hash] attributes Attributes to associate with the file (optional)
+    # @param [Hash] params Other parameters (see OpenAI docs)
+    # @raise (see LLM::Provider#request)
+    # @return [LLM::Response]
+    # @see https://platform.openai.com/docs/api-reference/vector_stores_files/createFile OpenAI docs
+    def add_file(vector:, file:, attributes: nil, **params)
+      vector_id = vector.respond_to?(:id) ? vector.id : vector
+      file_id = file.respond_to?(:id) ? file.id : file
+      req = Net::HTTP::Post.new("/v1/vector_stores/#{vector_id}/files", headers)
+      req.body = JSON.dump(params.merge({file_id:, attributes:}).compact)
+      res = execute(request: req)
+      LLM::Response.new(res)
+    end
+    alias_method :create_file, :add_file
+
+    ##
+    # Update a file in a vector store
+    # @param [String, #id] vector The ID of the vector store
+    # @param [String, #id] file The ID of the file to update
+    # @param [Hash] attributes Attributes to associate with the file
+    # @param [Hash] params Other parameters (see OpenAI docs)
+    # @raise (see LLM::Provider#request)
+    # @return [LLM::Response]
+    # @see https://platform.openai.com/docs/api-reference/vector_stores_files/updateAttributes OpenAI docs
+    def update_file(vector:, file:, attributes:, **params)
+      vector_id = vector.respond_to?(:id) ? vector.id : vector
+      file_id = file.respond_to?(:id) ? file.id : file
+      req = Net::HTTP::Post.new("/v1/vector_stores/#{vector_id}/files/#{file_id}", headers)
+      req.body = JSON.dump(params.merge({attributes:}).compact)
+      res = execute(request: req)
+      LLM::Response.new(res)
+    end
+
+    ##
+    # Get a file from a vector store
+    # @param [String, #id] vector The ID of the vector store
+    # @param [String, #id] file The ID of the file to retrieve
+    # @raise (see LLM::Provider#request)
+    # @return [LLM::Response]
+    # @see https://platform.openai.com/docs/api-reference/vector_stores_files/getFile OpenAI docs
+    def get_file(vector:, file:, **params)
+      vector_id = vector.respond_to?(:id) ? vector.id : vector
+      file_id = file.respond_to?(:id) ? file.id : file
+      query = URI.encode_www_form(params)
+      req = Net::HTTP::Get.new("/v1/vector_stores/#{vector_id}/files/#{file_id}?#{query}", headers)
+      res = execute(request: req)
+      LLM::Response.new(res)
+    end
+
+    ##
+    # Delete a file from a vector store
+    # @param [String, #id] vector The ID of the vector store
+    # @param [String, #id] file The ID of the file to delete
+    # @raise (see LLM::Provider#request)
+    # @return [LLM::Response]
+    # @see https://platform.openai.com/docs/api-reference/vector_stores_files/deleteFile OpenAI docs
+    def delete_file(vector:, file:)
+      vector_id = vector.respond_to?(:id) ? vector.id : vector
+      file_id = file.respond_to?(:id) ? file.id : file
+      req = Net::HTTP::Delete.new("/v1/vector_stores/#{vector_id}/files/#{file_id}", headers)
+      res = execute(request: req)
+      LLM::Response.new(res)
+    end
+
     private
 
     [:headers, :execute, :set_body_stream].each do |m|

--- a/spec/fixtures/cassettes/openai/vector_stores/successful_add_file.yml
+++ b/spec/fixtures/cassettes/openai/vector_stores/successful_add_file.yml
@@ -1,0 +1,391 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/vector_stores
+    body:
+      encoding: UTF-8
+      string: '{"name":"test store","file_ids":[]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:42:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_1a9ac908a174f48ccb2dfa0e3f158b8a
+      Openai-Processing-Ms:
+      - '166'
+      X-Envoy-Upstream-Service-Time:
+      - '171'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=NfzzF5OtcQlAUoljk7KRGln.aM7Bg9zlVdsq6X9zZ7I-1754890973-1.0.1.1-zwB0oBXKEJOTBsJHWkmQdXp9wNsP0LMq_GTj0Dm6C89Igh8uBnftrs8778Ej7BNyBcSaKrVEpJrD7GBqyw6ge6DgduNNOxbtHyJkiG2sWGA;
+        path=/; expires=Mon, 11-Aug-25 06:12:53 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=ykbic2_SbPUq2q2pMmOA58nKSyT8agzD2UGvjhEe7O4-1754890973577-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d569848d7f1aa9-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_689982dd56b48191be76825fde2fb173",
+          "object": "vector_store",
+          "created_at": 1754890973,
+          "name": "test store",
+          "description": null,
+          "usage_bytes": 0,
+          "file_counts": {
+            "in_progress": 0,
+            "completed": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "total": 0
+          },
+          "status": "completed",
+          "expires_after": null,
+          "expires_at": null,
+          "last_active_at": 1754890973,
+          "metadata": {}
+        }
+  recorded_at: Mon, 11 Aug 2025 05:42:39 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/files
+    body:
+      encoding: ASCII-8BIT
+      string: "--BOUNDARY__c7a2b04732f2654c893fa443b7064db2\r\nContent-Disposition:
+        form-data; name=\"file\";filename=\"haiku1.txt\"\r\nContent-Type: text/plain\r\n\r\nWhispers
+        through the trees,\nmoonlight dances on still waves --\nnight's breath softly
+        glows\n\r\n--BOUNDARY__c7a2b04732f2654c893fa443b7064db2\r\nContent-Disposition:
+        form-data; name=\"purpose\"\r\n\r\nassistants\r\n--BOUNDARY__c7a2b04732f2654c893fa443b7064db2--\r\n"
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=BOUNDARY__c7a2b04732f2654c893fa443b7064db2
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:42:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_a409aa8e267793c12aca003d37a92d30
+      Openai-Processing-Ms:
+      - '248'
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Envoy-Upstream-Service-Time:
+      - '251'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=1x58riVkX6hF2mtbtH3Q4r9c6462gcyK1HuPn8qmxAY-1754890974-1.0.1.1-vROHzFR2eClN6qcw1Nzj7lNanj6qau0rCdZ5ie24FKC_EY06tCMaMAlgcgYCInUeVJGgbBztN3OEMESKpF75coE17wMoA5kkOYMshZpcmNs;
+        path=/; expires=Mon, 11-Aug-25 06:12:54 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=aJP0A9PVLjpSHmsI0bgHyXKiiBDeOaNYmka7e3ThsRE-1754890974259-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d569899a30f1a1-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "object": "file",
+          "id": "file-N1HMUi73gKLpBjoiJhVn3b",
+          "purpose": "assistants",
+          "filename": "haiku1.txt",
+          "bytes": 91,
+          "created_at": 1754890973,
+          "expires_at": null,
+          "status": "processed",
+          "status_details": null
+        }
+  recorded_at: Mon, 11 Aug 2025 05:42:40 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/vector_stores/vs_689982dd56b48191be76825fde2fb173/files
+    body:
+      encoding: UTF-8
+      string: '{"file_id":"file-N1HMUi73gKLpBjoiJhVn3b"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:42:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_5c8e361c604b12d9cdcea25a926e7840
+      Openai-Processing-Ms:
+      - '692'
+      X-Envoy-Upstream-Service-Time:
+      - '704'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=pf_txy28ogvgChpkMNnO_.hYtS8VECI8LBTqnIY9Ni4-1754890975-1.0.1.1-wCd.kmwGql.Omipsc5lRuH.yKJwp1Mde10DOrVmRao1_30eA71sQLtfXX6E6dCSolhBZh_5GZSm8O0uL5vhGP7R3eamyCA7IAJcf3ZaxWnY;
+        path=/; expires=Mon, 11-Aug-25 06:12:55 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=_WcuHYfhnjLbycQO_jpsKRANdhQHWl6ZrJdD_SSZSQs-1754890975204-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d5698d8f385e0f-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "file-N1HMUi73gKLpBjoiJhVn3b",
+          "object": "vector_store.file",
+          "usage_bytes": 0,
+          "created_at": 1754890975,
+          "vector_store_id": "vs_689982dd56b48191be76825fde2fb173",
+          "status": "in_progress",
+          "last_error": null,
+          "chunking_strategy": {
+            "type": "static",
+            "static": {
+              "max_chunk_size_tokens": 800,
+              "chunk_overlap_tokens": 400
+            }
+          },
+          "attributes": {}
+        }
+  recorded_at: Mon, 11 Aug 2025 05:42:41 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/vector_stores/vs_689982dd56b48191be76825fde2fb173
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:42:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_d11bcf2805318a3f12a71ead201bf976
+      Openai-Processing-Ms:
+      - '2619'
+      X-Envoy-Upstream-Service-Time:
+      - '2627'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=mSOqQC1RVNsbmd3.mcjZ5YSjLcS9UwIHYI9CpL6.B3Y-1754890978-1.0.1.1-Vn_Dh5DtIfyGCRfFKqHztMNBn2NOenZRIRzSv_cTXdWZ0OASH.4PsPnx5SLDBFJud.WVcAtG1g7DFbUrwggAwLMKjcYRXnZF_NDkUQrA5L0;
+        path=/; expires=Mon, 11-Aug-25 06:12:58 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=JwngGudB5OCS2MMr4FZjxn0oheU2VYyi7cFQ3t1VeUo-1754890978115-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d56993bce3a67d-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_689982dd56b48191be76825fde2fb173",
+          "object": "vector_store.deleted",
+          "deleted": true
+        }
+  recorded_at: Mon, 11 Aug 2025 05:42:44 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/files/file-N1HMUi73gKLpBjoiJhVn3b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:42:58 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_eb5152e856965f140dfd6e3feb4c4c76
+      Openai-Processing-Ms:
+      - '253'
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Envoy-Upstream-Service-Time:
+      - '257'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=cSStWkjedXwsX6ZE0DqNj782LBW62mN5aH8eo16RqOE-1754890978-1.0.1.1-B0ZFvFdoOmIA_1xkxD5KEQ3AnsiZiFQsrnc8pX07gT.58MIWdkUsh8RxJhI0tLJfKFK2xOOYGnXQIAeZ5c675BnmPcDQ2Bnlzf6NwNZSDiw;
+        path=/; expires=Mon, 11-Aug-25 06:12:58 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=139DX9yD2IYMA5efRJy1hx8oZUWU..bfmiuC6urstCg-1754890978653-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d569a5eb281433-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "object": "file",
+          "deleted": true,
+          "id": "file-N1HMUi73gKLpBjoiJhVn3b"
+        }
+  recorded_at: Mon, 11 Aug 2025 05:42:44 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/openai/vector_stores/successful_all_files.yml
+++ b/spec/fixtures/cassettes/openai/vector_stores/successful_all_files.yml
@@ -1,0 +1,227 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/vector_stores
+    body:
+      encoding: UTF-8
+      string: '{"name":"test store","file_ids":[]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 06:18:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_7c62821eb52472112268c10542441e27
+      Openai-Processing-Ms:
+      - '156'
+      X-Envoy-Upstream-Service-Time:
+      - '159'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=TLVMXnHIAAmA0pSjSLvBK1pXD481aWQXv7ZeeZdbfNc-1754893130-1.0.1.1-wdyjViTOJq_pISGTaRAX3uoRYpJ_N5MbTPN97Fi6_0DWeVFy0K3q7LwdrP_IXA1dNtDQlqOyMWhIkaRKoFYEddU.GGcrcmIAuTEkUA2ORF4;
+        path=/; expires=Mon, 11-Aug-25 06:48:50 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=z6S5SFZ184xVjypENM_mcfTvCFT7jDcMS66IqEJXLMM-1754893130734-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d59e311fc0f200-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_68998b4a81748191b3ab6f2a3afe3eaf",
+          "object": "vector_store",
+          "created_at": 1754893130,
+          "name": "test store",
+          "description": null,
+          "usage_bytes": 0,
+          "file_counts": {
+            "in_progress": 0,
+            "completed": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "total": 0
+          },
+          "status": "completed",
+          "expires_after": null,
+          "expires_at": null,
+          "last_active_at": 1754893130,
+          "metadata": {}
+        }
+  recorded_at: Mon, 11 Aug 2025 06:18:36 GMT
+- request:
+    method: get
+    uri: https://api.openai.com/v1/vector_stores/vs_68998b4a81748191b3ab6f2a3afe3eaf/files
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 06:18:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_9b85c08ba9971384951964da7f469632
+      Openai-Processing-Ms:
+      - '139'
+      X-Envoy-Upstream-Service-Time:
+      - '142'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=9Txkn1zBNQx2onehGZhQH05urdT_rBiQDhYRrb4p_vw-1754893131-1.0.1.1-Zyqrx7aC9tWF8OTuzNnfW9RlL0CvSf8CcacfctckzAYB7PoIeXW8KLk6jDUsNaQCh6EGQwXIE2i9nPvxNwFKP35Vp2xnVVbbqFmxLFrQwm8;
+        path=/; expires=Mon, 11-Aug-25 06:48:51 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=iceaQ5NtdUMWzI_h2kA4euqqe7myX.wAPtIY7oSQsvk-1754893131162-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d59e33dfcb7a2f-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "object": "list",
+          "data": [],
+          "first_id": null,
+          "last_id": null,
+          "has_more": false
+        }
+  recorded_at: Mon, 11 Aug 2025 06:18:37 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/vector_stores/vs_68998b4a81748191b3ab6f2a3afe3eaf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 06:18:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_353350dfc501ca5b48c90a723b2e7555
+      Openai-Processing-Ms:
+      - '2686'
+      X-Envoy-Upstream-Service-Time:
+      - '2703'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=b9H0khiatrF6LP4kw3xQJvuns_eLAXiVqORsFiIBC8Y-1754893134-1.0.1.1-49pCjfxa7M7MnklJTLHSp_5aMud299MQHzQ2duNUJAzVUXgoIzI_k2qAgfafiv696fBDz5sQLL5SbRlkWOhuy1VNWwrxZDcVM3pMjyrzj0g;
+        path=/; expires=Mon, 11-Aug-25 06:48:54 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=gtvdaVcg9roQ1ni71dUXb4sdOSbKb71NoylE6nLR0fs-1754893134117-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d59e363b89f94d-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_68998b4a81748191b3ab6f2a3afe3eaf",
+          "object": "vector_store.deleted",
+          "deleted": true
+        }
+  recorded_at: Mon, 11 Aug 2025 06:18:40 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/openai/vector_stores/successful_delete_file.yml
+++ b/spec/fixtures/cassettes/openai/vector_stores/successful_delete_file.yml
@@ -1,0 +1,377 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/files
+    body:
+      encoding: ASCII-8BIT
+      string: "--BOUNDARY__f9c289af5335f56987446a7a59143c6e\r\nContent-Disposition:
+        form-data; name=\"file\";filename=\"haiku1.txt\"\r\nContent-Type: text/plain\r\n\r\nWhispers
+        through the trees,\nmoonlight dances on still waves --\nnight's breath softly
+        glows\n\r\n--BOUNDARY__f9c289af5335f56987446a7a59143c6e\r\nContent-Disposition:
+        form-data; name=\"purpose\"\r\n\r\nassistants\r\n--BOUNDARY__f9c289af5335f56987446a7a59143c6e--\r\n"
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=BOUNDARY__f9c289af5335f56987446a7a59143c6e
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:57:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_fca4e9d0b63b365ca8ef4b06bd1788c5
+      Openai-Processing-Ms:
+      - '327'
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=m6iX_BTsfS0Dn81Ex.8XMTYM_CloAkv2JaUtmxd6K0o-1754891842-1.0.1.1-57q3k4Bx1DRCr6kkFRYj11LDqprbcbpfb7Wm1OtAzKX8CdHlBrdl5FpRO5B5KZdJQ6mHMdh.uw9EQVoe2qH_qd4NrxzeZWdp2maJTKwBGlU;
+        path=/; expires=Mon, 11-Aug-25 06:27:22 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=dJ8oXR6k5YV0zY5908BxZUIE8iJi9pxnRVYaVZ7YPUc-1754891842494-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d57ebc38f92ce9-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "object": "file",
+          "id": "file-2T2kvexeE7RvMJeXZLTcTa",
+          "purpose": "assistants",
+          "filename": "haiku1.txt",
+          "bytes": 91,
+          "created_at": 1754891842,
+          "expires_at": null,
+          "status": "processed",
+          "status_details": null
+        }
+  recorded_at: Mon, 11 Aug 2025 05:57:08 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/vector_stores
+    body:
+      encoding: UTF-8
+      string: '{"name":"test store","file_ids":["file-2T2kvexeE7RvMJeXZLTcTa"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:57:23 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_e57980bfb2d884c0c6f1b129a64658a6
+      Openai-Processing-Ms:
+      - '541'
+      X-Envoy-Upstream-Service-Time:
+      - '545'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=WwkoS32zAyi0ZZnT.7nY7oyBmNnhdzsfawNrO0lLspw-1754891843-1.0.1.1-dKivC.wtyovi2suKrQHnP.YzWfRotRu2RXEtp7MKxgPyBLd_u1C0S.rG4tFGCYOjyWy1abh35_rmUEykAAZxX.qeWMd0pkqgiUJOpBXNS58;
+        path=/; expires=Mon, 11-Aug-25 06:27:23 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=5ZUZ5I3QXcXrg.Abm.yiZ20Meq_uLWSBufi30LL_5Qs-1754891843414-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d57ec00a72a427-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_68998642cce88191b3528220e3b90b0b",
+          "object": "vector_store",
+          "created_at": 1754891842,
+          "name": "test store",
+          "description": null,
+          "usage_bytes": 0,
+          "file_counts": {
+            "in_progress": 1,
+            "completed": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "total": 1
+          },
+          "status": "in_progress",
+          "expires_after": null,
+          "expires_at": null,
+          "last_active_at": 1754891842,
+          "metadata": {}
+        }
+  recorded_at: Mon, 11 Aug 2025 05:57:09 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/vector_stores/vs_68998642cce88191b3528220e3b90b0b/files/file-2T2kvexeE7RvMJeXZLTcTa
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:57:24 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_ee8d956055e176a92ad008e229ee0c73
+      Openai-Processing-Ms:
+      - '308'
+      X-Envoy-Upstream-Service-Time:
+      - '313'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=bacQNYEZOi_SW3n3FOYQ7yQm0IIH42XJ46c0SRYHPeo-1754891844-1.0.1.1-eiJZ0Y8UTcDZ0a7uCnHoU2uRveV3O250fq41A8QJiJCsxlVTO9NjQdVOwReFz6dWceA.LTQbmr3JsZZK3P6lpanDvCaWLZ.gorXOU0dCQAs;
+        path=/; expires=Mon, 11-Aug-25 06:27:24 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=2ULc0934f_nSVyToXF67z3Z6rQSc4b9nAzvtDpgF07o-1754891844105-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d57ec5cd2da405-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "file-2T2kvexeE7RvMJeXZLTcTa",
+          "object": "vector_store.file.deleted",
+          "deleted": true
+        }
+  recorded_at: Mon, 11 Aug 2025 05:57:10 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/vector_stores/vs_68998642cce88191b3528220e3b90b0b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:57:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_747a41b24501b563969160db67cbd5de
+      Openai-Processing-Ms:
+      - '2615'
+      X-Envoy-Upstream-Service-Time:
+      - '2618'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=4tqiKE3xki94jpEveQVANN0iEwITJekLY4gWjinWsWo-1754891846-1.0.1.1-LVgVAJQY1KMl0ldhEdqHocvzQIuE0iq_v.n9sIN1I5P.Cjoy0F6Sy0Shh.WnNRYWDe.091ZKapLCNlayTk6WHvLjWO.q4hyi1xD2XKEWV_A;
+        path=/; expires=Mon, 11-Aug-25 06:27:26 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=kGW2Wb8eYqLbcFYl1uOtvgIwxbfMTaPoQblV2fry_nw-1754891846972-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d57eca19c78776-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_68998642cce88191b3528220e3b90b0b",
+          "object": "vector_store.deleted",
+          "deleted": true
+        }
+  recorded_at: Mon, 11 Aug 2025 05:57:12 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/files/file-2T2kvexeE7RvMJeXZLTcTa
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:57:27 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_8c2780d0aa62dcee4583851fd1ff1731
+      Openai-Processing-Ms:
+      - '364'
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Envoy-Upstream-Service-Time:
+      - '368'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=jft3eTolQbzdYKxfknGSwdpkXDXx8YYvgEmxe8Aiukg-1754891847-1.0.1.1-T7yv4w96u3iVvowc.XoTDhzjJ54nLlvwIkaUqraR6OUXMZySHVkw.SrDPcpZbE5aaeNWTuznbkR84MJx.V86lHNY.xkZsQdxzOyPNNhRQdA;
+        path=/; expires=Mon, 11-Aug-25 06:27:27 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=SNvr.nPjOnoH497.zHeJBaTMQiA_IYA4rrY.7_SEmLk-1754891847759-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d57edc4abc6248-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "object": "file",
+          "deleted": true,
+          "id": "file-2T2kvexeE7RvMJeXZLTcTa"
+        }
+  recorded_at: Mon, 11 Aug 2025 05:57:13 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/openai/vector_stores/successful_get_file.yml
+++ b/spec/fixtures/cassettes/openai/vector_stores/successful_get_file.yml
@@ -1,0 +1,389 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/files
+    body:
+      encoding: ASCII-8BIT
+      string: "--BOUNDARY__5e11ead01ed14dfd84a0dd60c9adc460\r\nContent-Disposition:
+        form-data; name=\"file\";filename=\"haiku1.txt\"\r\nContent-Type: text/plain\r\n\r\nWhispers
+        through the trees,\nmoonlight dances on still waves --\nnight's breath softly
+        glows\n\r\n--BOUNDARY__5e11ead01ed14dfd84a0dd60c9adc460\r\nContent-Disposition:
+        form-data; name=\"purpose\"\r\n\r\nassistants\r\n--BOUNDARY__5e11ead01ed14dfd84a0dd60c9adc460--\r\n"
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=BOUNDARY__5e11ead01ed14dfd84a0dd60c9adc460
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:52:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_a434f2157d97fbb2a3f34e8d506e366e
+      Openai-Processing-Ms:
+      - '269'
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=h6sAB20qm9M.aUjfSh1ylZqkFurBwI7_jxtfcHBFKLQ-1754891569-1.0.1.1-BFZ5tx88DpxZCL7odSF4SHc8RyJ2yMHppsr3kZSZIZJ80NHg1vgZM0vmYKiafF2hOGbzeA_5v.xg5v36IFTElZCSj51UW40tizSMZDSXdOg;
+        path=/; expires=Mon, 11-Aug-25 06:22:49 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=8_RUA8WzigOcAtXOPkwrHayTHZUBFnTBuvJbiyUidXk-1754891569741-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d578140f47016c-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "object": "file",
+          "id": "file-HaGrBwgZCYdYKuUEmTW9ah",
+          "purpose": "assistants",
+          "filename": "haiku1.txt",
+          "bytes": 91,
+          "created_at": 1754891569,
+          "expires_at": null,
+          "status": "processed",
+          "status_details": null
+        }
+  recorded_at: Mon, 11 Aug 2025 05:52:35 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/vector_stores
+    body:
+      encoding: UTF-8
+      string: '{"name":"test store","file_ids":["file-HaGrBwgZCYdYKuUEmTW9ah"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:52:50 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_c6c9ab541ad931a21a0638c4838dd937
+      Openai-Processing-Ms:
+      - '605'
+      X-Envoy-Upstream-Service-Time:
+      - '610'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=ALIS__zPXQYYSg_XA5DY9gTQ_kKESLLYOWsXtd5pv_o-1754891570-1.0.1.1-64fag.ilAhzMBmMB7K8kOamEDDcUF8cKH6AJZ4PaqpumnvkGIDfg_cVdnci4Wpm3Ynw618Tma1qwJd8M9oHO2uR59VMwtc4Rih5zy49fGiE;
+        path=/; expires=Mon, 11-Aug-25 06:22:50 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=5tL4FcBtKHNCDBzWQqwLbfFQADuS2loOtNbfaGIfT8Q-1754891570637-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d578179fa2f1c9-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_6899853246c481919543c83762491846",
+          "object": "vector_store",
+          "created_at": 1754891570,
+          "name": "test store",
+          "description": null,
+          "usage_bytes": 0,
+          "file_counts": {
+            "in_progress": 1,
+            "completed": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "total": 1
+          },
+          "status": "in_progress",
+          "expires_after": null,
+          "expires_at": null,
+          "last_active_at": 1754891570,
+          "metadata": {}
+        }
+  recorded_at: Mon, 11 Aug 2025 05:52:36 GMT
+- request:
+    method: get
+    uri: https://api.openai.com/v1/vector_stores/vs_6899853246c481919543c83762491846/files/file-HaGrBwgZCYdYKuUEmTW9ah
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:52:51 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_150f16ba83cb99efa625bc47a20a8467
+      Openai-Processing-Ms:
+      - '74'
+      X-Envoy-Upstream-Service-Time:
+      - '76'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=eULcFcgMKcVLVWHRz6S.Dc54L9T_VZ0IXUe3PtlA.NA-1754891571-1.0.1.1-vMqVQoHu6_pMhtJi2kDmJgrwJ5iNM7g480_87na9jIvpEcqTMaZY3Fbkd2QHBjw1uQiqMbpcrrJSfsWQmBhEvInnNdov8pk5wKjNLiHX9hk;
+        path=/; expires=Mon, 11-Aug-25 06:22:51 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=OvPuFgKHizFisuqSCXSpHlJmY9V4.QJRX7JrWwYIazU-1754891571152-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d5781d39f3dc0c-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "file-HaGrBwgZCYdYKuUEmTW9ah",
+          "object": "vector_store.file",
+          "usage_bytes": 0,
+          "created_at": 1754891570,
+          "vector_store_id": "vs_6899853246c481919543c83762491846",
+          "status": "in_progress",
+          "last_error": null,
+          "chunking_strategy": {
+            "type": "static",
+            "static": {
+              "max_chunk_size_tokens": 800,
+              "chunk_overlap_tokens": 400
+            }
+          },
+          "attributes": {}
+        }
+  recorded_at: Mon, 11 Aug 2025 05:52:37 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/vector_stores/vs_6899853246c481919543c83762491846
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:52:53 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_e0b1b6fbdfd24f7e03e837d6750e9859
+      Openai-Processing-Ms:
+      - '2511'
+      X-Envoy-Upstream-Service-Time:
+      - '2514'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=apiAj9mov0dkoMnp.JR5CNqCJRhUxHVwA7etTtQ692Q-1754891573-1.0.1.1-VYuFcQL1RMv8Bn8G_P6xK1.MFzhC3vAty.71hbdfdz9dMpUZ4wVZKf1qCWTrxbjSR6sDp2TPGdv5ke8dvB.Df76_plB9xTzwGblzI4MzzEk;
+        path=/; expires=Mon, 11-Aug-25 06:22:53 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=w07eiKwQPJb1uLw43lEqG0gcpC14bRnY2A1LsKVV2Wo-1754891573946-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d578206a4f0126-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_6899853246c481919543c83762491846",
+          "object": "vector_store.deleted",
+          "deleted": true
+        }
+  recorded_at: Mon, 11 Aug 2025 05:52:39 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/files/file-HaGrBwgZCYdYKuUEmTW9ah
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 05:52:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_d2913731e0fd6dcbb86875da97fef113
+      Openai-Processing-Ms:
+      - '259'
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Envoy-Upstream-Service-Time:
+      - '263'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=mgp50sJJaX_tz8k0eBitoMCkwvN5sGzUkjYWr50.97g-1754891574-1.0.1.1-0W9nCqGemsjR8Zh09DiUO4jCGlOEAqk4U4lUK6y.2AafeWLXULYfPW2iW4C32imn_fDtP7po.CxXa6CZsn7xqCO723p9acMhLT6S7Xg7cfY;
+        path=/; expires=Mon, 11-Aug-25 06:22:54 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=B57gQgbz.Le21L9.97l2oJMb8NDURkxKl8XR6HsW17o-1754891574500-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d57831d9ab4ae9-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "object": "file",
+          "deleted": true,
+          "id": "file-HaGrBwgZCYdYKuUEmTW9ah"
+        }
+  recorded_at: Mon, 11 Aug 2025 05:52:40 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/cassettes/openai/vector_stores/successful_update_file.yml
+++ b/spec/fixtures/cassettes/openai/vector_stores/successful_update_file.yml
@@ -1,0 +1,391 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/files
+    body:
+      encoding: ASCII-8BIT
+      string: "--BOUNDARY__e7166643d92a09f373272b80559b384b\r\nContent-Disposition:
+        form-data; name=\"file\";filename=\"haiku1.txt\"\r\nContent-Type: text/plain\r\n\r\nWhispers
+        through the trees,\nmoonlight dances on still waves --\nnight's breath softly
+        glows\n\r\n--BOUNDARY__e7166643d92a09f373272b80559b384b\r\nContent-Disposition:
+        form-data; name=\"purpose\"\r\n\r\nassistants\r\n--BOUNDARY__e7166643d92a09f373272b80559b384b--\r\n"
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=BOUNDARY__e7166643d92a09f373272b80559b384b
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 06:14:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_18fd78b066c0b50ac725da9bd6894277
+      Openai-Processing-Ms:
+      - '438'
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=kn6rNPlCXcVph9hWgMl_Z.5FCMINg8u.69uNL0rJvJo-1754892844-1.0.1.1-r59LU7W5571ehdeAJODF1p208sR4PnHyg2IwAP11bCkzE0cL3X8386yjrSwM2iMJ6iDua8qNd6JiK3Opb9f5NTl2JmZZr5v6s8EkX4zzeBk;
+        path=/; expires=Mon, 11-Aug-25 06:44:04 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=N4OxmI61vMF6OChc2mbOSqPhQsCNvFUAOsp_XReVs98-1754892844458-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d5973209097ff0-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "object": "file",
+          "id": "file-5UakgbBWynhqCA238TFs4L",
+          "purpose": "assistants",
+          "filename": "haiku1.txt",
+          "bytes": 91,
+          "created_at": 1754892844,
+          "expires_at": null,
+          "status": "processed",
+          "status_details": null
+        }
+  recorded_at: Mon, 11 Aug 2025 06:13:50 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/vector_stores
+    body:
+      encoding: UTF-8
+      string: '{"name":"test store","file_ids":["file-5UakgbBWynhqCA238TFs4L"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 06:14:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_693bb72493aa4baf9a653000e5dac27c
+      Openai-Processing-Ms:
+      - '5705'
+      X-Envoy-Upstream-Service-Time:
+      - '5707'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=S3xY_bXslRIkq0NyIL1Jz6NLbt0eHNPK.AXZPVxg60c-1754892850-1.0.1.1-ECWeBph24e9LhuhwN6EAGZ7oyTpAWpv1MK0GUgtQuv7p.UcrvTyWyfJfYp5AGMzR7to4HAbeZiN89XNzVjlc8mK8W3aTiQQrLaL.32VftJU;
+        path=/; expires=Mon, 11-Aug-25 06:44:10 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=rVj7c8wzvJ3lvIcQ5RNA1fIwrUdgFBPFObKbjaHVTJI-1754892850586-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d597368f9a01b0-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_68998a2ce9808191ae5074f189cc3d14",
+          "object": "vector_store",
+          "created_at": 1754892844,
+          "name": "test store",
+          "description": null,
+          "usage_bytes": 0,
+          "file_counts": {
+            "in_progress": 1,
+            "completed": 0,
+            "failed": 0,
+            "cancelled": 0,
+            "total": 1
+          },
+          "status": "in_progress",
+          "expires_after": null,
+          "expires_at": null,
+          "last_active_at": 1754892844,
+          "metadata": {}
+        }
+  recorded_at: Mon, 11 Aug 2025 06:13:56 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/vector_stores/vs_68998a2ce9808191ae5074f189cc3d14/files/file-5UakgbBWynhqCA238TFs4L
+    body:
+      encoding: UTF-8
+      string: '{"attributes":{"tag":"updated"}}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 06:14:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_edcb8aa2c95802817bf3c0269bd0ee18
+      Openai-Processing-Ms:
+      - '694'
+      X-Envoy-Upstream-Service-Time:
+      - '727'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=Xt_vavDyb.fAdsurv3zjF_3QWwNFQc7IBK01z.xNxoE-1754892851-1.0.1.1-xWr49tgPxPcGoPh5coDXYsuFy3qP.qs2jLsUdIWMQn_mRUBo1YGWASKYrzDS0G03OLGyHFpgVLpEe.JIekzQPmAuMZ5gF7mfQ3xOS6l5Vlk;
+        path=/; expires=Mon, 11-Aug-25 06:44:11 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=IeqpwmCWPSesub6Mm9O0l_rnc6Ciqt8I3QwzSC_jcLk-1754892851594-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d5975cc83f1b30-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "file-5UakgbBWynhqCA238TFs4L",
+          "object": "vector_store.file",
+          "usage_bytes": 1115,
+          "created_at": 1754892850,
+          "vector_store_id": "vs_68998a2ce9808191ae5074f189cc3d14",
+          "status": "completed",
+          "last_error": null,
+          "chunking_strategy": {
+            "type": "static",
+            "static": {
+              "max_chunk_size_tokens": 800,
+              "chunk_overlap_tokens": 400
+            }
+          },
+          "attributes": {
+            "tag": "updated"
+          }
+        }
+  recorded_at: Mon, 11 Aug 2025 06:13:57 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/vector_stores/vs_68998a2ce9808191ae5074f189cc3d14
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 06:14:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_e58a5fb9c52984dce2fc995a508fac2c
+      Openai-Processing-Ms:
+      - '2424'
+      X-Envoy-Upstream-Service-Time:
+      - '2427'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=SbQo6VjTgmGBx2vrxaUMhqJYPrcnL_cthMlT1gv8Djs-1754892854-1.0.1.1-kMthVnAOp.ovsSZ7Ml2pyGaU4LY4jNWRG3_JJneQSkHZGxLEXt8fSxxwbc1LUTPO_7ZG1V7cSkJs3pbVADQUsYXFpviFWkaBD3dyostYyI0;
+        path=/; expires=Mon, 11-Aug-25 06:44:14 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=6aG6uB8MBzhf.08HWNSRkJJ0ddHcb7sxKyRrTnLBtyM-1754892854928-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d597670aeef25a-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "vs_68998a2ce9808191ae5074f189cc3d14",
+          "object": "vector_store.deleted",
+          "deleted": true
+        }
+  recorded_at: Mon, 11 Aug 2025 06:14:00 GMT
+- request:
+    method: delete
+    uri: https://api.openai.com/v1/files/file-5UakgbBWynhqCA238TFs4L
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer TOKEN
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 11 Aug 2025 06:14:15 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-j1pztzt5nogpcsid23u7gskj
+      Openai-Project:
+      - proj_YSiqu4bByPgi6EwPnLiY8irR
+      X-Request-Id:
+      - req_326f1f04064601048e6597bd87811908
+      Openai-Processing-Ms:
+      - '310'
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Envoy-Upstream-Service-Time:
+      - '314'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=4BO4R06eiBkiaBO2jiyYVWpVe5t6JYsMCd.mLGdEYM0-1754892855-1.0.1.1-pZ.XzJOashTxvoy649i3RUDBUkhjG3hw5fpTnvr82Fuh13pji21qNvKz6xoGUMcBhGyOXEEuUW8YX6BmGknc87s514L4WswNzlmIvgRPnbw;
+        path=/; expires=Mon, 11-Aug-25 06:44:15 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=ncyChRnEztqJAIRiwkL51RopY.lJn7TrvN12E4jUoA8-1754892855768-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 96d59777ba6077c4-GRU
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "object": "file",
+          "deleted": true,
+          "id": "file-5UakgbBWynhqCA238TFs4L"
+        }
+  recorded_at: Mon, 11 Aug 2025 06:14:01 GMT
+recorded_with: VCR 6.3.1

--- a/spec/openai/vector_stores_spec.rb
+++ b/spec/openai/vector_stores_spec.rb
@@ -56,4 +56,110 @@ RSpec.describe "LLM::OpenAI::VectorStores" do
       )
     end
   end
+
+  context "when givee a successful 'all files' operation",
+          vcr: {cassette_name: "openai/vector_stores/successful_all_files"} do
+    let(:store) { provider.vector_stores.create(name: "test store") }
+    subject { provider.vector_stores.all_files(vector: store) }
+    after { provider.vector_stores.delete(vector: store) }
+
+    it "is successful" do
+      is_expected.to be_ok
+    end
+
+    it "includes data array" do
+      is_expected.to have_attributes(
+        "data" => be_an(Array)
+      )
+    end
+  end
+
+  context "when given a successful 'add file' operation",
+          vcr: {cassette_name: "openai/vector_stores/successful_add_file"} do
+    let(:store) { provider.vector_stores.create(name: "test store") }
+    let(:file) { provider.files.create(file: "spec/fixtures/documents/haiku1.txt") }
+    subject { provider.vector_stores.add_file(vector: store, file:) }
+
+    after do
+      provider.vector_stores.delete(vector: store)
+      provider.files.delete(file:)
+    end
+
+    it "is successful" do
+      is_expected.to be_ok
+    end
+
+    it "returns the file" do
+      is_expected.to have_attributes(
+        "id" => instance_of(String)
+      )
+    end
+  end
+
+  context "when given a successful 'update file' operation",
+          vcr: {cassette_name: "openai/vector_stores/successful_update_file"} do
+    let(:store) { provider.vector_stores.create(name: "test store", file_ids: [file.id]) }
+    let(:file) { provider.files.create(file: "spec/fixtures/documents/haiku1.txt") }
+    subject { provider.vector_stores.update_file(vector: store, file:, attributes: {tag: "updated"}) }
+
+    after do
+      provider.vector_stores.delete(vector: store)
+      provider.files.delete(file:)
+    end
+
+    it "is successful" do
+      is_expected.to be_ok
+    end
+
+    it "returns the file" do
+      is_expected.to have_attributes(
+        "id" => file.id,
+        "attributes" => have_attributes("tag" => "updated")
+      )
+    end
+  end
+
+  context "when given a successful 'get file' operation",
+          vcr: {cassette_name: "openai/vector_stores/successful_get_file"} do
+    let(:store) { provider.vector_stores.create(name: "test store", file_ids: [file.id]) }
+    let(:file) { provider.files.create(file: "spec/fixtures/documents/haiku1.txt") }
+    subject { provider.vector_stores.get_file(vector: store, file:) }
+
+    after do
+      provider.vector_stores.delete(vector: store)
+      provider.files.delete(file:)
+    end
+
+    it "is successful" do
+      is_expected.to be_ok
+    end
+
+    it "returns the file" do
+      is_expected.to have_attributes(
+        "id" => file.id
+      )
+    end
+  end
+
+  context "when given a successful 'delete file' operation",
+          vcr: {cassette_name: "openai/vector_stores/successful_delete_file"} do
+    let(:store) { provider.vector_stores.create(name: "test store", file_ids: [file.id]) }
+    let(:file) { provider.files.create(file: "spec/fixtures/documents/haiku1.txt") }
+    subject { provider.vector_stores.delete_file(vector: store, file:) }
+
+    after do
+      provider.vector_stores.delete(vector: store)
+      provider.files.delete(file:)
+    end
+
+    it "is successful" do
+      is_expected.to be_ok
+    end
+
+    it "returns deleted status" do
+      is_expected.to have_attributes(
+        "deleted" => true
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Context

This change includes new methods for managing the files 
that belong to a vector store. Previously files could only be 
added when a vector store was created. Now they can be 
added after the fact, with or without attributes included, 
and so on.